### PR TITLE
fix(ui): render DatapointRow as a JSX element with a stable key

### DIFF
--- a/src/components/detail.spec.tsx
+++ b/src/components/detail.spec.tsx
@@ -10,7 +10,7 @@ import { render } from "@testing-library/preact";
 // provider (react-query's hooks require the preact/compat React alias, which is
 // not wired up under vitest).
 const { datapointRowSpy } = vi.hoisted(() => ({
-  datapointRowSpy: vi.fn(() => null),
+  datapointRowSpy: vi.fn<[unknown], null>(() => null),
 }));
 
 vi.mock("./datapointRow", () => ({ default: datapointRowSpy }));
@@ -56,7 +56,9 @@ describe("Detail recent data", () => {
     render(<Detail g={makeGoal(DATAPOINT_ID)} position={1} count={1} />);
 
     expect(datapointRowSpy).toHaveBeenCalledTimes(1);
-    expect(datapointRowSpy).toHaveBeenCalledWith({
+    // DatapointRow is rendered as a JSX element, so Preact calls it with
+    // (props, context). Assert on the props (first arg); `key` is stripped out.
+    expect(datapointRowSpy.mock.calls[0][0]).toEqual({
       goal: "weight",
       point: {
         id: DATAPOINT_ID,

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -108,17 +108,18 @@ export default function Detail({
             </tr>
           </thead>
           <tbody>
-            {g.recent_data.map((point) =>
-              DatapointRow({
-                goal: g.slug,
-                point: {
+            {g.recent_data.map((point) => (
+              <DatapointRow
+                key={point.id}
+                goal={g.slug}
+                point={{
                   id: point.id,
                   daystamp: point.daystamp,
                   comment: point.comment,
                   value: point.value,
-                },
-              })
-            )}
+                }}
+              />
+            ))}
           </tbody>
         </table>
 


### PR DESCRIPTION
Render each "Recent Data" row as a JSX element instead of calling
`DatapointRow({...})` directly.

Since `DatapointRow` calls hooks (`useGoalMutations` → `useMutation`),
invoking it as a plain function inside `.map()` runs those hooks in a
loop in `Detail`'s render — a Rules-of-Hooks violation that can corrupt
per-row mutation state when the number of datapoints changes. Rendering
`<DatapointRow key={point.id} ... />` makes each row a real component
instance with its own hook state and stable keyed reconciliation.

`detail.spec.tsx` is updated to assert on the props Preact passes the
component (it's now called as `(props, context)` with `key` stripped),
preserving the test's intent: the real string id is passed down.

### Note on scope (post-rebase)

This PR originally also added an optimistic "queued" flag and cache
invalidation around datapoint mutations. Both were dropped during the
rebase onto `main` because `main` already does them better:

- `useGoalMutations` / `goalMutationOptions` own scoped optimistic
  `queued` updates **with error rollback** and invalidation on settle.
- The `point.id.$oid` bug (real cause of #8) was already fixed on `main`
  by reading `point.id` as a plain string.

What remains here is the JSX/keying fix, which `main` had not yet applied.
