### PR TITLE
Show flag for completed goals instead of skull

### DIFF
--- a/src/components/countdown.css
+++ b/src/components/countdown.css
@@ -3,3 +3,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.countdown-icon {
+  vertical-align: middle;
+}

--- a/src/components/countdown.spec.tsx
+++ b/src/components/countdown.spec.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/preact";
+import Countdown from "./countdown";
+import { Goal } from "../services/beeminder";
+
+function makeGoal(overrides: Partial<Goal>): Goal {
+  return {
+    baremin: "1",
+    losedate: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 3,
+    won: false,
+    ...overrides,
+  } as Goal;
+}
+
+describe("Countdown", () => {
+  it("shows a checkered flag when the goal is won", () => {
+    const { container } = render(<Countdown g={makeGoal({ won: true })} />);
+
+    expect(container.querySelector(".lucide-flag")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-skull")).not.toBeInTheDocument();
+  });
+
+  it("shows the flag for a won goal even if its losedate has passed", () => {
+    const losedate = Math.floor(Date.now() / 1000) - 60;
+
+    const { container } = render(
+      <Countdown g={makeGoal({ won: true, losedate })} />
+    );
+
+    expect(container.querySelector(".lucide-flag")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-skull")).not.toBeInTheDocument();
+  });
+
+  it("shows a skull when a goal has derailed (losedate passed, not won)", () => {
+    const losedate = Math.floor(Date.now() / 1000) - 60;
+
+    const { container } = render(
+      <Countdown g={makeGoal({ won: false, losedate })} />
+    );
+
+    expect(container.querySelector(".lucide-skull")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-flag")).not.toBeInTheDocument();
+  });
+
+  it("shows the remaining time for an active goal", () => {
+    const { container } = render(<Countdown g={makeGoal({})} />);
+
+    expect(container.querySelector(".lucide-flag")).not.toBeInTheDocument();
+    expect(container.querySelector(".lucide-skull")).not.toBeInTheDocument();
+    expect(container.textContent).toContain("in");
+  });
+});

--- a/src/components/countdown.spec.tsx
+++ b/src/components/countdown.spec.tsx
@@ -42,6 +42,17 @@ describe("Countdown", () => {
     expect(container.querySelector(".lucide-flag")).not.toBeInTheDocument();
   });
 
+  it("shows an hourglass when the goal is due within a second", () => {
+    const losedate = Date.now() / 1000 + 0.5;
+
+    const { container } = render(
+      <Countdown g={makeGoal({ won: false, losedate })} />
+    );
+
+    expect(container.querySelector(".lucide-hourglass")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-skull")).not.toBeInTheDocument();
+  });
+
   it("shows the remaining time for an active goal", () => {
     const { container } = render(<Countdown g={makeGoal({})} />);
 

--- a/src/components/countdown.spec.tsx
+++ b/src/components/countdown.spec.tsx
@@ -54,10 +54,15 @@ describe("Countdown", () => {
   });
 
   it("shows the remaining time for an active goal", () => {
-    const { container } = render(<Countdown g={makeGoal({})} />);
+    // 2.5 days out so Math.floor lands on 2d regardless of sub-second drift.
+    const losedate = Math.floor(Date.now() / 1000) + 60 * 60 * 60;
+
+    const { container } = render(
+      <Countdown g={makeGoal({ losedate, baremin: "1" })} />
+    );
 
     expect(container.querySelector(".lucide-flag")).not.toBeInTheDocument();
     expect(container.querySelector(".lucide-skull")).not.toBeInTheDocument();
-    expect(container.textContent).toContain("in");
+    expect(container.textContent).toContain("1 in 2d");
   });
 });

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -2,7 +2,7 @@ import { Goal } from "../services/beeminder";
 import { useState, useEffect } from "preact/hooks";
 import "./countdown.css";
 import { ComponentChildren } from "preact";
-import { Flag, Skull } from "lucide-preact";
+import { Flag, Hourglass, Skull } from "lucide-preact";
 
 const Unit: Record<string, number> = {
   s: 1,
@@ -77,7 +77,17 @@ export default function Countdown({ g }: { g: Goal }) {
 
   const u = findUnit(seconds);
 
-  if (!u) return <W>🤷‍♂️</W>;
+  if (!u)
+    return (
+      <W>
+        <Hourglass
+          class="countdown-icon"
+          size={20}
+          role="img"
+          aria-label="Due now"
+        />
+      </W>
+    );
 
   return (
     <W>

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -2,6 +2,7 @@ import { Goal } from "../services/beeminder";
 import { useState, useEffect } from "preact/hooks";
 import "./countdown.css";
 import { ComponentChildren } from "preact";
+import { Flag, Skull } from "lucide-preact";
 
 const Unit: Record<string, number> = {
   s: 1,
@@ -50,7 +51,29 @@ export default function Countdown({ g }: { g: Goal }) {
     };
   }, [g, seconds]);
 
-  if (seconds < 0) return <W>💀</W>;
+  if (g.won)
+    return (
+      <W>
+        <Flag
+          class="countdown-icon"
+          size={20}
+          role="img"
+          aria-label="Goal completed"
+        />
+      </W>
+    );
+
+  if (seconds < 0)
+    return (
+      <W>
+        <Skull
+          class="countdown-icon"
+          size={20}
+          role="img"
+          aria-label="Goal derailed"
+        />
+      </W>
+    );
 
   const u = findUnit(seconds);
 


### PR DESCRIPTION
## Problem

When a goal reaches its end, the grid countdown showed a 💀 skull — making a **successfully completed** goal look like it had failed/derailed. The skull (and the other countdown glyphs) were raw emoji, which render inconsistently across devices.

## Change

`Countdown` now distinguishes a won goal from a derailed one, and every state uses a **`lucide-preact`** icon instead of emoji:

- **Completed (`g.won`)** → checkered-flag icon (`Flag`), regardless of `losedate`.
- **Derailed (`losedate` passed and not won)** → skull icon (`Skull`).
- **Due within a second (`!u`)** → hourglass icon (`Hourglass`), replacing the old 🤷‍♂️ shrug.
- Active goals are unchanged (still show the remaining-time countdown).

Icons match the rest of the app (controls, header, etc.), render consistently across devices, and get a `role="img"` + `aria-label` for accessibility.

## Tests

Added `countdown.spec.tsx` covering:
- won goal → flag, not skull
- won goal with a past `losedate` → still flag
- past `losedate`, not won → skull
- due within a second → hourglass
- active goal → remaining-time text

All tests pass; typecheck and lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Countdown component now displays icons (flag, skull, hourglass) instead of emoji for completed, derailed, and due-soon goals.

* **Tests**
  * Added comprehensive test suite for Countdown component covering all goal states and conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/bm/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->