### PR TITLE
Fix delete datapoint sending undefined id (404)

### DIFF
--- a/src/components/detail.spec.tsx
+++ b/src/components/detail.spec.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/preact";
+
+// The Beeminder API returns recent_data[].id as a plain string. Detail used to
+// read it as `point.id.$oid`, which was always undefined and made delete hit
+// /datapoints/undefined.json (404). This test pins Detail to passing the real
+// string id down to DatapointRow.
+//
+// DatapointRow and Controls are stubbed so the test doesn't need a react-query
+// provider (react-query's hooks require the preact/compat React alias, which is
+// not wired up under vitest); useGoals is stubbed for the same reason.
+const { datapointRowSpy } = vi.hoisted(() => ({
+  datapointRowSpy: vi.fn(() => null),
+}));
+
+vi.mock("./datapointRow", () => ({ default: datapointRowSpy }));
+vi.mock("./controls", () => ({ default: () => null }));
+vi.mock("../useGoals", () => ({ default: () => ({ data: [] }) }));
+
+import Detail from "./detail";
+import { Goal } from "../services/beeminder";
+
+const DATAPOINT_ID = "6a135ad0f0168a8b2d437020";
+
+function makeGoal(recentId: string): Goal {
+  return {
+    slug: "weight",
+    limsumdate: "2026-05-24",
+    roadstatuscolor: "green",
+    title: "Lose weight",
+    gunits: "lbs",
+    runits: "day",
+    aggday: "last",
+    deadline: 0,
+    autoratchet: null,
+    svg_url: "https://example.com/graph.svg",
+    mathishard: [0, 0, 1.5],
+    fineprint: "",
+    recent_data: [
+      {
+        canonical: "",
+        comment: "test comment",
+        created_at: "",
+        daystamp: "20260524",
+        fulltext: "",
+        id: recentId,
+        measured_at: "",
+        origin: "",
+        value: 1,
+      },
+    ],
+  } as Goal;
+}
+
+describe("Detail recent data", () => {
+  it("passes the datapoint's string id down, not an undefined $oid", () => {
+    render(<Detail g={makeGoal(DATAPOINT_ID)} />);
+
+    expect(datapointRowSpy).toHaveBeenCalledTimes(1);
+    expect(datapointRowSpy).toHaveBeenCalledWith({
+      goal: "weight",
+      point: {
+        id: DATAPOINT_ID,
+        daystamp: "20260524",
+        comment: "test comment",
+        value: 1,
+      },
+    });
+  });
+});

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -115,7 +115,7 @@ export default function Detail({
               DatapointRow({
                 goal: g.slug,
                 point: {
-                  id: point.id.$oid,
+                  id: point.id,
                   daystamp: point.daystamp,
                   comment: point.comment,
                   value: point.value,

--- a/src/services/beeminder/index.ts
+++ b/src/services/beeminder/index.ts
@@ -109,9 +109,7 @@ export type Goal = {
     created_at: string;
     daystamp: string;
     fulltext: string;
-    id: {
-      $oid: string;
-    };
+    id: string;
     measured_at: string;
     origin: string;
     urtext?: string;


### PR DESCRIPTION
## The bug

Deleting a datapoint from a goal's **Recent Data** table silently fails — the row stays visible. The delete request goes to `/datapoints/undefined.json` and Beeminder returns **404**:

```
DELETE https://www.beeminder.com/api/v1/users/me/goals/dishes/datapoints/undefined.json → 404
```

## Root cause

`detail.tsx` read the datapoint id as `point.id.$oid`, but the Beeminder API returns `recent_data[].id` as a **plain string**, not a `{ $oid }` object. Confirmed against the live API:

```json
"recent_data": [{ "id": "6a135ad0f0168a8b2d437020", ... }]
```

So `point.id.$oid` was always `undefined`. The `recent_data` type in `services/beeminder/index.ts` declared `id: { $oid: string }`, which is why TypeScript never caught it.

## Fix

- `detail.tsx`: read `point.id` directly.
- `services/beeminder/index.ts`: correct the `recent_data` type to `id: string`.

The corrected type also guards against regression — `point.id.$oid` now fails `tsc`.

Once the right id is sent, the delete succeeds and the existing global `onSettled` in `queryClient.ts` (which invalidates all queries after every mutation) refetches the goals, so the row disappears.

## Relationship to #10

This is the actual cause of #8. **PR #10** tried to fix #8 by adding cache invalidation to the delete/copy mutations, but that change is a no-op: `queryClient.ts` already invalidates every query on `onSettled` after any mutation. The delete never failed for cache reasons — it failed because it sent `undefined` as the id. #10 should be closed in favor of this.

## Verification

- `pnpm checkTs` — passes
- `pnpm test` — 22/22 pass
- Live API confirmed `recent_data[].id` is a string

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated datapoint identifier formatting in recent data displays for simplified, consistent handling and correct datapoint recognition throughout the application.

* **Tests**
  * Added comprehensive test coverage to validate that datapoint identifiers in recent data are properly transmitted between components and accurately reference the intended data records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/bm/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->