### PR TITLE
Consolidate goal mutations into one module (closes #15)

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -1,26 +1,10 @@
 import "./goal.css";
-import { createDatapoint, refreshGraph, Goal } from "../services/beeminder";
-import { useMutation } from "@tanstack/react-query";
-import queryClient from "../queryClient";
+import { Goal } from "../services/beeminder";
+import useGoalMutations from "../useGoalMutations";
 import cnx from "../cnx";
 import { useState } from "preact/hooks";
 import "./controls.css";
 import { Plus, RefreshCw } from "lucide-preact";
-
-async function q(slug: string, mutate: () => Promise<unknown>) {
-  const cached = queryClient.getQueryData<Goal[]>(["goals"]);
-  if (!cached) return;
-  const index = cached.findIndex((x) => x.slug === slug);
-  if (index === -1) return;
-  cached[index] = {
-    ...cached[index],
-    queued: true,
-  };
-  queryClient.setQueryData(["goals"], cached);
-  const result = await mutate();
-  await queryClient.invalidateQueries(["goals"]);
-  return result;
-}
 
 function getErrorMessage(error: unknown) {
   if (typeof error === "string") return error;
@@ -50,22 +34,12 @@ export default function Controls({
   refreshOnly?: boolean;
 }) {
   const [value, setValue] = useState<string>("");
-  const c = useMutation(
-    (v: number) => q(g.slug, () => createDatapoint(g.slug, v)),
-    {
-      onSuccess: () => setValue(""),
-    }
-  );
+  const { addDatapoint, refresh: refreshGoal } = useGoalMutations(g.slug);
   const autodata = getAutodata(g);
-  const r = useMutation(() =>
-    q(g.slug, () =>
-      typeof autodata === "string" ? fetch(autodata) : refreshGraph(g.slug)
-    )
-  );
-  const isLoading = c.isLoading || r.isLoading || g.queued;
-  const isError = c.isError || r.isError;
+  const isLoading = addDatapoint.isLoading || refreshGoal.isLoading || g.queued;
+  const isError = addDatapoint.isError || refreshGoal.isError;
   const tooltip = isError
-    ? getErrorMessage(c.error || r.error)
+    ? getErrorMessage(addDatapoint.error || refreshGoal.error)
     : autodata
     ? "Refresh"
     : "Add datapoint";
@@ -73,12 +47,13 @@ export default function Controls({
   const submit = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     const v = parseValue(value);
-    if (Number.isFinite(v)) c.mutate(v);
+    if (Number.isFinite(v))
+      addDatapoint.mutate(v, { onSuccess: () => setValue("") });
   };
 
   const refresh = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
-    r.mutate();
+    refreshGoal.mutate(autodata);
   };
 
   if (refreshOnly && !autodata) return null;

--- a/src/components/datapointRow.tsx
+++ b/src/components/datapointRow.tsx
@@ -1,5 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
-import { createDatapoint, deleteDatapoint } from "../services/beeminder";
+import useGoalMutations from "../useGoalMutations";
 import cnx from "../cnx";
 import "./datapointRow.css";
 import { Copy, Trash } from "lucide-preact";
@@ -16,8 +15,7 @@ export default function DatapointRow({
     value: number;
   };
 }) {
-  const del = useMutation(() => deleteDatapoint(goal, point.id));
-  const copy = useMutation(() => createDatapoint(goal, point.value));
+  const { removeDatapoint: del, copyDatapoint: copy } = useGoalMutations(goal);
 
   return (
     <tr key={point.id} data-id={point.id} class="datapoint-row">
@@ -30,7 +28,7 @@ export default function DatapointRow({
           class={cnx("icon-button", del.isLoading && "spin")}
           onClick={() => {
             if (confirm("Are you sure you want to delete this datapoint?")) {
-              del.mutate();
+              del.mutate(point.id);
             }
           }}
         >
@@ -39,7 +37,7 @@ export default function DatapointRow({
         <button
           type="button"
           class={cnx("icon-button", copy.isLoading && "spin")}
-          onClick={() => copy.mutate()}
+          onClick={() => copy.mutate(point.value)}
         >
           <Copy />
         </button>

--- a/src/queryClient.ts
+++ b/src/queryClient.ts
@@ -2,13 +2,12 @@ import { QueryClient } from "@tanstack/react-query";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { persistQueryClient } from "@tanstack/react-query-persist-client";
 
+// Goal mutations handle their own (scoped) cache invalidation in
+// useGoalMutations, so there's no blanket mutation onSettled here.
 const queryClient: QueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       cacheTime: 1000 * 60 * 60 * 24, // 24 hours
-    },
-    mutations: {
-      onSettled: () => queryClient.invalidateQueries(),
     },
   },
 });

--- a/src/useGoalMutations.spec.ts
+++ b/src/useGoalMutations.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// react-query hooks can't run under this repo's vitest setup (the preact/compat
+// alias isn't wired up), so we don't mount a provider or call the hook. Instead
+// we exercise goalMutationOptions' cache callbacks directly against a mocked
+// queryClient — mirroring the pure-function spec style used elsewhere.
+// `vi.hoisted` defines the mock above the hoisted `vi.mock` factory.
+const { queryClient } = vi.hoisted(() => ({
+  queryClient: {
+    cancelQueries: vi.fn(),
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+  },
+}));
+
+vi.mock("./queryClient", () => ({ default: queryClient }));
+
+import { goalMutationOptions } from "./useGoalMutations";
+import { GOALS_QUERY_KEY } from "./useGoals";
+import { Goal } from "./services/beeminder";
+
+type Updater = (goals?: Goal[]) => Goal[] | undefined;
+
+function goal(slug: string, queued = false): Goal {
+  return { slug, queued } as Goal;
+}
+
+// The functional updater handed to the most recent setQueryData call.
+function lastUpdater(): Updater {
+  const calls = queryClient.setQueryData.mock.calls as Array<[unknown, Updater]>;
+  return calls[calls.length - 1][1];
+}
+
+describe("goalMutationOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("onMutate", () => {
+    it("optimistically marks only the matching goal as queued, immutably", async () => {
+      const before = [goal("a"), goal("b")];
+      queryClient.getQueryData.mockReturnValue(before);
+
+      const context = await goalMutationOptions("a").onMutate?.(undefined);
+
+      // Snapshots the previous state for rollback.
+      expect(context).toEqual({ previous: before });
+
+      // Cancels in-flight goal fetches so they can't clobber our optimistic write.
+      expect(queryClient.cancelQueries).toHaveBeenCalledWith(GOALS_QUERY_KEY);
+
+      // Apply the functional updater that was handed to setQueryData.
+      const after = lastUpdater()(before);
+
+      expect(after).toEqual([goal("a", true), goal("b")]);
+      // Original array and the untouched goal are not mutated.
+      expect(before[0].queued).toBe(false);
+      expect(after).not.toBe(before);
+      expect(after?.[1]).toBe(before[1]);
+    });
+
+    it("no-ops the updater when the cache is empty", async () => {
+      queryClient.getQueryData.mockReturnValue(undefined);
+
+      const context = await goalMutationOptions("a").onMutate?.(undefined);
+
+      expect(context).toEqual({ previous: undefined });
+      expect(lastUpdater()(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("onError", () => {
+    it("rolls back to the previous snapshot", () => {
+      const previous = [goal("a")];
+
+      goalMutationOptions("a").onError?.(new Error("boom"), undefined, {
+        previous,
+      });
+
+      expect(queryClient.setQueryData).toHaveBeenCalledWith(
+        GOALS_QUERY_KEY,
+        previous
+      );
+    });
+
+    it("does nothing when there is no previous snapshot", () => {
+      goalMutationOptions("a").onError?.(new Error("boom"), undefined, {
+        previous: undefined,
+      });
+
+      expect(queryClient.setQueryData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onSettled", () => {
+    it("invalidates the scoped goals query", () => {
+      goalMutationOptions("a").onSettled?.(undefined, null, undefined, undefined);
+
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+        GOALS_QUERY_KEY
+      );
+    });
+  });
+});

--- a/src/useGoalMutations.ts
+++ b/src/useGoalMutations.ts
@@ -1,0 +1,70 @@
+import {
+  useMutation,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+import queryClient from "./queryClient";
+import { GOALS_QUERY_KEY } from "./useGoals";
+import {
+  createDatapoint,
+  deleteDatapoint,
+  refreshGraph,
+  Goal,
+} from "./services/beeminder";
+
+type Context = { previous?: Goal[] };
+
+// Every goal mutation behaves the same way around the goals cache:
+//   1. optimistically mark the goal as `queued` so the UI shows it working,
+//   2. roll that back if the mutation fails, and
+//   3. invalidate the goals query once it settles so we refetch the truth.
+//
+// This is the one place that knows the cache shape and the query key. Callers
+// just express intent.
+function goalMutationOptions<TVariables>(
+  slug: string
+): UseMutationOptions<unknown, unknown, TVariables, Context> {
+  return {
+    onMutate: async () => {
+      await queryClient.cancelQueries(GOALS_QUERY_KEY);
+      const previous = queryClient.getQueryData<Goal[]>(GOALS_QUERY_KEY);
+      queryClient.setQueryData<Goal[]>(GOALS_QUERY_KEY, (goals) =>
+        goals?.map((g) => (g.slug === slug ? { ...g, queued: true } : g))
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(GOALS_QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries(GOALS_QUERY_KEY),
+  };
+}
+
+// All the ways a goal can change, behind one interface. `refresh` takes the
+// goal's autodata (a string URL fetches that endpoint; otherwise we ask
+// Beeminder to refresh the graph) so the caller doesn't decide how to refresh.
+export default function useGoalMutations(slug: string) {
+  const addDatapoint = useMutation(
+    (value: number) => createDatapoint(slug, value),
+    goalMutationOptions<number>(slug)
+  );
+
+  const copyDatapoint = useMutation(
+    (value: number) => createDatapoint(slug, value),
+    goalMutationOptions<number>(slug)
+  );
+
+  const removeDatapoint = useMutation(
+    (id: string) => deleteDatapoint(slug, id),
+    goalMutationOptions<string>(slug)
+  );
+
+  const refresh = useMutation(
+    (autodata: string | boolean) =>
+      typeof autodata === "string" ? fetch(autodata) : refreshGraph(slug),
+    goalMutationOptions<string | boolean>(slug)
+  );
+
+  return { addDatapoint, copyDatapoint, removeDatapoint, refresh };
+}

--- a/src/useGoalMutations.ts
+++ b/src/useGoalMutations.ts
@@ -19,8 +19,8 @@ type Context = { previous?: Goal[] };
 //   3. invalidate the goals query once it settles so we refetch the truth.
 //
 // This is the one place that knows the cache shape and the query key. Callers
-// just express intent.
-function goalMutationOptions<TVariables>(
+// just express intent. Exported for unit testing of the cache callbacks.
+export function goalMutationOptions<TVariables>(
   slug: string
 ): UseMutationOptions<unknown, unknown, TVariables, Context> {
   return {

--- a/src/useGoals.ts
+++ b/src/useGoals.ts
@@ -2,8 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { API_KEY, logout } from "./auth";
 import { getGoals, Goal } from "./services/beeminder";
 
+// The single source of truth for the goals query key. Anything that reads or
+// mutates the cached goals list keys off this.
+export const GOALS_QUERY_KEY = ["goals"] as const;
+
 export default function useGoals() {
-  return useQuery<Goal[], Response>(["goals"], () => getGoals(), {
+  return useQuery<Goal[], Response>(GOALS_QUERY_KEY, () => getGoals(), {
     enabled: !!API_KEY,
     refetchInterval: (d) => (d?.find((g) => g.queued) ? 3000 : 60000),
     refetchIntervalInBackground: false,


### PR DESCRIPTION
Closes #15.

## Problem

Goal-mutation behavior was smeared across three places that didn't agree:

- `controls.tsx` had a private `q()` that poked the goals cache directly and mutated the cached array **in place**.
- `datapointRow.tsx` ran raw `useMutation` for copy/delete with **no** optimistic marking.
- `queryClient.ts` added a *global* blanket `mutations.onSettled → invalidateQueries()`.

The `["goals"]` query key was a magic string repeated across files, so every caller had to know the cache shape.

## Change

Introduce `useGoalMutations(slug)` — the single module that owns the goals query key and the optimistic-`queued` + scoped-invalidate behavior — exposing `addDatapoint`, `copyDatapoint`, `removeDatapoint`, and `refresh`. Callers now just express intent.

- Copy/delete get the **same** optimistic-`queued` treatment as add/refresh (consistency fix).
- The in-place cache mutation is replaced with an **immutable map + rollback on error** (`onMutate`/`onError`).
- The global blanket invalidate is dropped in favor of **per-mutation scoped invalidation** of the goals key.
- `["goals"]` is exported from `useGoals` as `GOALS_QUERY_KEY` (single source of truth).

## Scope notes

- `getAutodata` (fineprint parsing) stays in `controls.tsx` — that consolidation is issue #17.
- `DatapointRow`'s `{ goal, point }` prop shape is unchanged, keeping `detail.spec.tsx` green.

## Verification

- `npm run checkTs` — clean
- `npx vitest run` — 23/23 pass
- `eslint` on changed files — clean (pre-existing `groupGoals.spec.ts` lint errors are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)