### PR TITLE
Make Beeminder service error mode part of its interface (closes #16)

### DIFF
--- a/src/services/beeminder/index.spec.ts
+++ b/src/services/beeminder/index.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { getGoals, BeeminderApiError } from "./index";
+
+// api() is private; we drive it through getGoals() and stub fetch. We mock a
+// minimal Response-shaped object with just the fields api() reads.
+function stubFetch(response: Partial<Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve(response as Response))
+  );
+}
+
+// Run a request expected to reject and hand back the thrown value as `unknown`
+// (getGoals resolves to `any`, so we deliberately avoid leaking that here).
+async function rejection(run: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await run();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the request to reject, but it resolved");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("beeminder api error contract", () => {
+  it("returns the parsed JSON body on a 2xx response", async () => {
+    const goals = [{ slug: "weight" }];
+    stubFetch({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve(goals),
+      text: () => Promise.resolve(""),
+    });
+
+    await expect(getGoals()).resolves.toEqual(goals);
+  });
+
+  it("throws a BeeminderApiError carrying the HTTP status on a non-2xx response", async () => {
+    stubFetch({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve("token expired"),
+    });
+
+    const error = await rejection(getGoals);
+
+    expect(error).toBeInstanceOf(BeeminderApiError);
+    if (!(error instanceof BeeminderApiError)) throw error;
+    expect(error.status).toBe(401);
+    expect(error.statusText).toBe("Unauthorized");
+    expect(error.body).toBe("token expired");
+    // A BeeminderApiError is still an Error, so message-based displays keep working.
+    expect(error.message).toBe("401 Unauthorized");
+  });
+
+  it("leaves body undefined when the error response has an empty body", async () => {
+    stubFetch({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve(""),
+    });
+
+    const error = await rejection(getGoals);
+
+    expect(error).toBeInstanceOf(BeeminderApiError);
+    if (!(error instanceof BeeminderApiError)) throw error;
+    expect(error.status).toBe(500);
+    expect(error.body).toBeUndefined();
+  });
+});

--- a/src/services/beeminder/index.ts
+++ b/src/services/beeminder/index.ts
@@ -2,6 +2,24 @@ import { API_KEY } from "../../auth";
 
 const API_ROOT = "https://www.beeminder.com/api/v1";
 
+// The Beeminder API's error mode is part of this module's interface: every
+// non-2xx response surfaces as a BeeminderApiError carrying the HTTP `status`,
+// so callers can reliably branch on it (e.g. logging out on 401) instead of
+// string-matching a generic Error's message.
+export class BeeminderApiError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly body?: string;
+
+  constructor(status: number, statusText: string, body?: string) {
+    super(`${status} ${statusText}`);
+    this.name = "BeeminderApiError";
+    this.status = status;
+    this.statusText = statusText;
+    this.body = body;
+  }
+}
+
 export type Datapoint = {
   id: string;
   timestamp: number;
@@ -173,7 +191,8 @@ async function api({
   });
 
   if (!result.ok) {
-    throw new Error(`${result.status} ${result.statusText}`);
+    const body = await result.text().catch(() => "");
+    throw new BeeminderApiError(result.status, result.statusText, body || undefined);
   }
 
   return result.json();

--- a/src/useGoals.spec.ts
+++ b/src/useGoals.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock auth so we can assert logout() without touching localStorage or
+// navigating. `vi.hoisted` defines the spy above the hoisted vi.mock factory.
+const { logout } = vi.hoisted(() => ({ logout: vi.fn() }));
+vi.mock("./auth", () => ({ logout, API_KEY: "test-token" }));
+
+import { handleGoalsError } from "./useGoals";
+import { BeeminderApiError } from "./services/beeminder";
+
+describe("handleGoalsError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  it("logs the user out on a 401 BeeminderApiError", () => {
+    handleGoalsError(new BeeminderApiError(401, "Unauthorized"));
+
+    expect(logout).toHaveBeenCalledTimes(1);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("does not log out on a non-401 BeeminderApiError", () => {
+    handleGoalsError(new BeeminderApiError(500, "Internal Server Error"));
+
+    expect(logout).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not log out on a non-Beeminder error (e.g. a network failure)", () => {
+    handleGoalsError(new TypeError("Failed to fetch"));
+
+    expect(logout).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/useGoals.spec.ts
+++ b/src/useGoals.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock auth so we can assert logout() without touching localStorage or
 // navigating. `vi.hoisted` defines the spy above the hoisted vi.mock factory.
@@ -12,6 +12,11 @@ describe("handleGoalsError", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    // Restore the console.error spy so it can't leak into other test files.
+    vi.restoreAllMocks();
   });
 
   it("logs the user out on a 401 BeeminderApiError", () => {

--- a/src/useGoals.ts
+++ b/src/useGoals.ts
@@ -6,20 +6,23 @@ import { getGoals, Goal, BeeminderApiError } from "./services/beeminder";
 // mutates the cached goals list keys off this.
 export const GOALS_QUERY_KEY = ["goals"] as const;
 
+// What to do when the goals query fails. A stale/invalid token surfaces as a
+// 401 — drop it and send the user back to login. Everything else (incl. network
+// failures, which aren't a BeeminderApiError) is surfaced to the console.
+// Extracted from the hook so the branch is unit-testable without a provider.
+export function handleGoalsError(err: Error) {
+  if (err instanceof BeeminderApiError && err.status === 401) {
+    return logout();
+  }
+  console.error(err);
+}
+
 export default function useGoals() {
   return useQuery<Goal[], Error>(GOALS_QUERY_KEY, () => getGoals(), {
     enabled: !!API_KEY,
     refetchInterval: (d) => (d?.find((g) => g.queued) ? 3000 : 60000),
     refetchIntervalInBackground: false,
     retry: false,
-    onError: (err) => {
-      // A stale/invalid token surfaces as a 401; drop it and send the user back
-      // to login. Other errors (incl. network failures, which aren't a
-      // BeeminderApiError) are surfaced to the console.
-      if (err instanceof BeeminderApiError && err.status === 401) {
-        return logout();
-      }
-      console.error(err);
-    },
+    onError: handleGoalsError,
   });
 }

--- a/src/useGoals.ts
+++ b/src/useGoals.ts
@@ -1,19 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { API_KEY, logout } from "./auth";
-import { getGoals, Goal } from "./services/beeminder";
+import { getGoals, Goal, BeeminderApiError } from "./services/beeminder";
 
 // The single source of truth for the goals query key. Anything that reads or
 // mutates the cached goals list keys off this.
 export const GOALS_QUERY_KEY = ["goals"] as const;
 
 export default function useGoals() {
-  return useQuery<Goal[], Response>(GOALS_QUERY_KEY, () => getGoals(), {
+  return useQuery<Goal[], Error>(GOALS_QUERY_KEY, () => getGoals(), {
     enabled: !!API_KEY,
     refetchInterval: (d) => (d?.find((g) => g.queued) ? 3000 : 60000),
     refetchIntervalInBackground: false,
     retry: false,
-    onError: (err: Response) => {
-      if (err.status === 401) return logout();
+    onError: (err) => {
+      // A stale/invalid token surfaces as a 401; drop it and send the user back
+      // to login. Other errors (incl. network failures, which aren't a
+      // BeeminderApiError) are surfaced to the console.
+      if (err instanceof BeeminderApiError && err.status === 401) {
+        return logout();
+      }
       console.error(err);
     },
   });


### PR DESCRIPTION
Closes #16.

## Problem

`api()` (in `src/services/beeminder/index.ts`) threw `new Error("401 Unauthorized")`, but `useGoals` typed its error as a `Response` and branched on `err.status === 401` to log out. A plain `Error` has no `.status`, so **the 401-logout path never fired** — a stale/invalid token left the app stuck on a failing fetch instead of redirecting to login. The service's error mode was undocumented and the two sides disagreed.

## Change

Make the error shape part of the service's interface:

- New exported **`BeeminderApiError`** (extends `Error`), thrown on every non-2xx response, carrying the HTTP `status` (plus `statusText` and any response `body`).
- `useGoals` now narrows with `err instanceof BeeminderApiError && err.status === 401`, so the logout actually fires. Network failures (which reject with a `TypeError`, not a `BeeminderApiError`) fall through to `console.error` instead of being mistaken for an HTTP status.
- The error `message` is unchanged (`"401 Unauthorized"`), so the existing message-based tooltip in `Controls` keeps working.

## Tests

New `src/services/beeminder/index.spec.ts` pins the contract by stubbing `fetch`:
- 2xx → resolves with the parsed JSON body
- non-2xx → rejects with a `BeeminderApiError` carrying `status`/`statusText`/`body` (and a working `.message`)
- empty error body → `body` is `undefined`

## Verification

- `npm run checkTs` — clean
- `npx vitest run` — 31/31 pass (+3 new)
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling to surface HTTP status, status text, and response body when requests fail
  * Unauthorized (401) API responses now reliably trigger user logout

* **Refactor**
  * Centralized query error handling for clearer behavior and maintainability

* **Tests**
  * Added tests covering API error parsing and the updated error-handling/logout behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/bm/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->