### PR TITLE
Extract a goal navigation module (closes #18)

### DIFF
--- a/src/components/detail.spec.tsx
+++ b/src/components/detail.spec.tsx
@@ -8,14 +8,13 @@ import { render } from "@testing-library/preact";
 //
 // DatapointRow and Controls are stubbed so the test doesn't need a react-query
 // provider (react-query's hooks require the preact/compat React alias, which is
-// not wired up under vitest); useGoals is stubbed for the same reason.
+// not wired up under vitest).
 const { datapointRowSpy } = vi.hoisted(() => ({
   datapointRowSpy: vi.fn(() => null),
 }));
 
 vi.mock("./datapointRow", () => ({ default: datapointRowSpy }));
 vi.mock("./controls", () => ({ default: () => null }));
-vi.mock("../useGoals", () => ({ default: () => ({ data: [] }) }));
 
 import Detail from "./detail";
 import { Goal } from "../services/beeminder";

--- a/src/components/detail.spec.tsx
+++ b/src/components/detail.spec.tsx
@@ -53,7 +53,7 @@ function makeGoal(recentId: string): Goal {
 
 describe("Detail recent data", () => {
   it("passes the datapoint's string id down, not an undefined $oid", () => {
-    render(<Detail g={makeGoal(DATAPOINT_ID)} />);
+    render(<Detail g={makeGoal(DATAPOINT_ID)} position={1} count={1} />);
 
     expect(datapointRowSpy).toHaveBeenCalledTimes(1);
     expect(datapointRowSpy).toHaveBeenCalledWith({

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -34,8 +34,8 @@ export default function Detail({
   goNext?: VoidFunction;
   goPrev?: VoidFunction;
   // 1-based position of this goal among all goals, and the total, for the pager.
-  position?: number;
-  count?: number;
+  position: number;
+  count: number;
 }) {
   const r = sigfigs(g.mathishard[2]);
 

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -1,8 +1,6 @@
 import { USERNAME, API_KEY } from "../auth";
 import { Goal } from "../services/beeminder";
 import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
-import groupGoals from "../lib/groupGoals";
-import useGoals from "../useGoals";
 import Controls from "./controls";
 import DatapointRow from "./datapointRow";
 import "./detail.css";
@@ -29,19 +27,17 @@ export default function Detail({
   g,
   goPrev,
   goNext,
+  position,
+  count,
 }: {
   g: Goal;
   goNext?: VoidFunction;
   goPrev?: VoidFunction;
+  // 1-based position of this goal among all goals, and the total, for the pager.
+  position?: number;
+  count?: number;
 }) {
-  const { data = [] } = useGoals();
-  const grouped = groupGoals(data);
-  const goals = Object.values(grouped).flat();
-  const i = goals.findIndex((g2) => g2.slug === g.slug);
-  const p = i === undefined ? "?" : i + 1;
   const r = sigfigs(g.mathishard[2]);
-
-  console.log({ g });
 
   return (
     <div
@@ -59,7 +55,7 @@ export default function Detail({
         </button>
         <span>{g.limsumdate}</span>
         <span>
-          {p} of {goals.length}
+          {position} of {count}
         </span>
         <button
           onClick={() => goNext?.()}

--- a/src/components/goals.tsx
+++ b/src/components/goals.tsx
@@ -49,7 +49,7 @@ export function Goals({ goals }: { goals: Goal[] }) {
           <G key={g.slug} g={g} onClick={() => setSlug(g.slug)} />
         ))}
       </div>
-      <Modal open={!!slug} onClose={close}>
+      <Modal open={!!nav.current} onClose={close}>
         {nav.current && (
           <Detail
             g={nav.current}

--- a/src/components/goals.tsx
+++ b/src/components/goals.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from "preact/hooks";
 import { Goal } from "../services/beeminder";
 import groupGoals from "../lib/groupGoals";
+import goalNavigation from "../lib/goalNavigation";
 import Detail from "./detail";
 import G from "./goal";
 import "./goals.css";
@@ -9,13 +10,16 @@ import Modal from "./modal";
 export function Goals({ goals }: { goals: Goal[] }) {
   const [slug, setSlug] = useState<string>();
   const g = useMemo(() => groupGoals(goals), [goals]);
-  const a = Object.values(g).flat();
-  const i = a.findIndex((g) => g.slug === slug);
-  const c = a[i];
-  const n = a[i + 1];
-  const p = a[i - 1];
-  const goPrev = useMemo(() => (p ? () => setSlug(p.slug) : undefined), [p]);
-  const goNext = useMemo(() => (n ? () => setSlug(n.slug) : undefined), [n]);
+  const nav = useMemo(() => goalNavigation(goals, slug), [goals, slug]);
+  const { prev, next } = nav;
+  const goPrev = useMemo(
+    () => (prev ? () => setSlug(prev.slug) : undefined),
+    [prev]
+  );
+  const goNext = useMemo(
+    () => (next ? () => setSlug(next.slug) : undefined),
+    [next]
+  );
   const close = () => setSlug(undefined);
 
   useEffect(() => {
@@ -45,11 +49,17 @@ export function Goals({ goals }: { goals: Goal[] }) {
           <G key={g.slug} g={g} onClick={() => setSlug(g.slug)} />
         ))}
       </div>
-      {
-        <Modal open={!!slug} onClose={close}>
-          <Detail g={c} goPrev={goPrev} goNext={goNext} />
-        </Modal>
-      }
+      <Modal open={!!slug} onClose={close}>
+        {nav.current && (
+          <Detail
+            g={nav.current}
+            goPrev={goPrev}
+            goNext={goNext}
+            position={nav.index + 1}
+            count={nav.count}
+          />
+        )}
+      </Modal>
     </div>
   );
 }

--- a/src/lib/goalNavigation.spec.ts
+++ b/src/lib/goalNavigation.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { Goal } from "../services/beeminder";
+import goalNavigation from "./goalNavigation";
+
+function goal(props: Partial<Goal>): Goal {
+  return props as Goal;
+}
+
+// A goal that lands in the "today" group (safebuf 0); `losedate` controls the
+// sort order within the group.
+function today(slug: string, losedate: number): Goal {
+  return goal({ slug, safebuf: 0, losedate });
+}
+
+describe("goalNavigation", () => {
+  it("returns an empty navigation for no goals", () => {
+    const nav = goalNavigation([], undefined);
+    expect(nav.ordered).toEqual([]);
+    expect(nav.count).toBe(0);
+    expect(nav.index).toBe(-1);
+    expect(nav.current).toBeUndefined();
+    expect(nav.prev).toBeUndefined();
+    expect(nav.next).toBeUndefined();
+  });
+
+  it("orders goals by group (pinned, today, next, later), flattened", () => {
+    const goals = [
+      goal({ slug: "later1", safebuf: 10, todayta: true, losedate: 5 }),
+      goal({ slug: "pinned1", fineprint: "#bmPin", safebuf: 3, losedate: 4 }),
+      goal({ slug: "today1", safebuf: 0, losedate: 3 }),
+    ];
+
+    expect(goalNavigation(goals).ordered.map((x) => x.slug)).toEqual([
+      "pinned1",
+      "today1",
+      "later1",
+    ]);
+  });
+
+  it("reports index, count and neighbours for a middle goal", () => {
+    const goals = [today("a", 1), today("b", 2), today("c", 3)];
+    const nav = goalNavigation(goals, "b");
+
+    expect(nav.index).toBe(1);
+    expect(nav.count).toBe(3);
+    expect(nav.current?.slug).toBe("b");
+    expect(nav.prev?.slug).toBe("a");
+    expect(nav.next?.slug).toBe("c");
+  });
+
+  it("has no prev at the start and no next at the end", () => {
+    const goals = [today("a", 1), today("b", 2), today("c", 3)];
+
+    const first = goalNavigation(goals, "a");
+    expect(first.prev).toBeUndefined();
+    expect(first.next?.slug).toBe("b");
+
+    const last = goalNavigation(goals, "c");
+    expect(last.next).toBeUndefined();
+    expect(last.prev?.slug).toBe("b");
+  });
+
+  it("treats an absent current slug as before the list: index -1, next is the first goal", () => {
+    // Preserves the prior grid behaviour where, with nothing open, advancing
+    // ("next") jumps to the first goal.
+    const goals = [today("a", 1), today("b", 2)];
+    const nav = goalNavigation(goals, undefined);
+
+    expect(nav.index).toBe(-1);
+    expect(nav.current).toBeUndefined();
+    expect(nav.prev).toBeUndefined();
+    expect(nav.next?.slug).toBe("a");
+  });
+});

--- a/src/lib/goalNavigation.ts
+++ b/src/lib/goalNavigation.ts
@@ -22,7 +22,15 @@ export default function goalNavigation(
   goals: Goal[],
   currentSlug?: string
 ): GoalNavigation {
-  const ordered = Object.values(groupGoals(goals)).flat();
+  // Flatten the groups explicitly so the display/traversal order is locked here
+  // rather than relying on object key iteration order.
+  const grouped = groupGoals(goals);
+  const ordered = [
+    ...grouped.pinned,
+    ...grouped.today,
+    ...grouped.next,
+    ...grouped.later,
+  ];
   const index = ordered.findIndex((g) => g.slug === currentSlug);
 
   return {

--- a/src/lib/goalNavigation.ts
+++ b/src/lib/goalNavigation.ts
@@ -1,0 +1,36 @@
+import { Goal } from "../services/beeminder";
+import groupGoals from "./groupGoals";
+
+export type GoalNavigation = {
+  // All goals in dashboard display order (pinned, today, next, later), flattened.
+  ordered: Goal[];
+  // Zero-based position of the current goal in `ordered`; -1 when there is no
+  // current goal or it isn't in the list.
+  index: number;
+  // Total number of goals in `ordered`.
+  count: number;
+  // The current goal and its neighbours in display order (undefined at the ends).
+  current?: Goal;
+  prev?: Goal;
+  next?: Goal;
+};
+
+// The single definition of how the dashboard orders goals and how you move
+// between them. Both the goal grid and the detail pager navigate through this,
+// so "prev/next" and "X of N" can't drift apart (they share one ordered list).
+export default function goalNavigation(
+  goals: Goal[],
+  currentSlug?: string
+): GoalNavigation {
+  const ordered = Object.values(groupGoals(goals)).flat();
+  const index = ordered.findIndex((g) => g.slug === currentSlug);
+
+  return {
+    ordered,
+    index,
+    count: ordered.length,
+    current: ordered[index],
+    prev: ordered[index - 1],
+    next: ordered[index + 1],
+  };
+}


### PR DESCRIPTION
Closes #18.

## Problem

`goals.tsx` and `detail.tsx` each independently computed goal ordering with `Object.values(groupGoals(...)).flat()` + `findIndex` — to get current/prev/next and the "X of N" pager. Two copies of the same traversal.

Worse, they fed it **different inputs**: `goals.tsx` used the *filtered* (searched) list it receives from `App`, while `detail.tsx` called `useGoals()` for the *unfiltered* list. So with a search active, the pager's "X of N" count disagreed with the actual prev/next navigation.

## Change

Introduce **`src/lib/goalNavigation.ts`** — the single definition of how the dashboard orders goals and moves between them:

```ts
goalNavigation(goals, currentSlug) -> { ordered, index, count, current, prev, next }
```

- `goals.tsx` owns navigation (it has the real, filtered list) and passes `position`/`count` down to `Detail`.
- `Detail` no longer re-derives anything — it drops its own `useGoals` + `groupGoals` and just renders the position it's given.

This removes the duplication **and** the drift in one move: prev/next and "X of N" now share one ordered list.

### Incidental
- `Detail` is now rendered only when there's a current goal (guards an undefined-goal edge that previously could crash).
- Removed a stray `console.log({ g })` from `Detail`.
- `detail.spec.tsx` drops its now-unused `useGoals` mock (Detail no longer imports it).

Behavior is otherwise preserved — the flatten order (pinned→today→next→later) and the "advance from nothing → first goal" edge are kept (the latter is pinned by a test).

## Tests

New `src/lib/goalNavigation.spec.ts` (5 cases): empty list; group ordering; middle-goal index/count/neighbours; no-prev-at-start / no-next-at-end; absent-slug edge.

## Verification

- `npm run checkTs` — clean
- `npx vitest run` — 52/52 pass (+5 new)
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized goal navigation logic into a shared utility, improving code organization and testability.
  * Updated the detail view to receive pagination information as props rather than computing it internally.

* **Tests**
  * Added comprehensive test coverage for the new navigation logic.
  * Updated test setup for improved spy management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/bm/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->