### PR TITLE
Extract a session module from auth (closes #19)

### DIFF
--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -58,12 +58,13 @@ describe("session", () => {
   });
 
   describe("logout", () => {
-    it("clears the stored credentials", () => {
+    it("clears the stored credentials and redirects to the root", () => {
       login("alice", "tok_123");
       logout();
 
       expect(getCredentials()).toEqual({ username: "", apiKey: "" });
       expect(isAuthenticated()).toBe(false);
+      expect(window.location.href).toBe("/");
     });
   });
 });

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getCredentials, isAuthenticated, login, logout } from "./auth";
+
+describe("session", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // login/logout navigate via `window.location.href = "/"`. happy-dom can't
+    // resolve that relative URL without a base, so stub location with a plain
+    // writable object — this also lets us assert the redirect.
+    Object.defineProperty(window, "location", {
+      value: { href: "https://bm.test/" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe("getCredentials", () => {
+    it("returns empty strings when nothing is stored", () => {
+      expect(getCredentials()).toEqual({ username: "", apiKey: "" });
+    });
+
+    it("returns the stored username and api key", () => {
+      localStorage.setItem("username", "alice");
+      localStorage.setItem("api_key", "tok_123");
+      expect(getCredentials()).toEqual({ username: "alice", apiKey: "tok_123" });
+    });
+  });
+
+  describe("isAuthenticated", () => {
+    it("is false when there is no api key", () => {
+      expect(isAuthenticated()).toBe(false);
+    });
+
+    it("is false when only a username is stored", () => {
+      localStorage.setItem("username", "alice");
+      expect(isAuthenticated()).toBe(false);
+    });
+
+    it("is true once an api key is stored", () => {
+      localStorage.setItem("api_key", "tok_123");
+      expect(isAuthenticated()).toBe(true);
+    });
+  });
+
+  describe("login", () => {
+    it("persists the credentials so getCredentials/isAuthenticated reflect them", () => {
+      login("alice", "tok_123");
+
+      expect(getCredentials()).toEqual({ username: "alice", apiKey: "tok_123" });
+      expect(isAuthenticated()).toBe(true);
+    });
+
+    it("redirects to the root", () => {
+      login("alice", "tok_123");
+
+      expect(window.location.href).toBe("/");
+    });
+  });
+
+  describe("logout", () => {
+    it("clears the stored credentials", () => {
+      login("alice", "tok_123");
+      logout();
+
+      expect(getCredentials()).toEqual({ username: "", apiKey: "" });
+      expect(isAuthenticated()).toBe(false);
+    });
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,14 +1,35 @@
-export const USERNAME = localStorage.getItem("username") || "";
-export const API_KEY = localStorage.getItem("api_key") || "";
+// The session module: the one place that knows where Beeminder credentials
+// live (localStorage) and the seam tests can stand in for. Credentials are read
+// on demand rather than captured at import, so callers never see a stale value
+// (the previous module-level consts only refreshed on a full page reload).
+
+const USERNAME_KEY = "username";
+const TOKEN_KEY = "api_key";
+
+export type Credentials = {
+  username: string;
+  apiKey: string;
+};
+
+export function getCredentials(): Credentials {
+  return {
+    username: localStorage.getItem(USERNAME_KEY) || "",
+    apiKey: localStorage.getItem(TOKEN_KEY) || "",
+  };
+}
+
+export function isAuthenticated(): boolean {
+  return getCredentials().apiKey !== "";
+}
 
 export function login(username: string, apiKey: string) {
-  localStorage.setItem("username", username);
-  localStorage.setItem("api_key", apiKey);
+  localStorage.setItem(USERNAME_KEY, username);
+  localStorage.setItem(TOKEN_KEY, apiKey);
   window.location.href = "/";
 }
 
 export function logout() {
-  localStorage.removeItem("username");
-  localStorage.removeItem("api_key");
+  localStorage.removeItem(USERNAME_KEY);
+  localStorage.removeItem(TOKEN_KEY);
   window.location.href = "/";
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -3,7 +3,7 @@ import { Goal } from "../services/beeminder";
 import "./app.css";
 import { Goals } from "./goals";
 import { useState } from "preact/hooks";
-import { API_KEY } from "../auth";
+import { isAuthenticated } from "../auth";
 import useGoals from "../useGoals";
 import Login from "./login";
 import queryClient from "../queryClient";
@@ -15,7 +15,7 @@ function _App() {
   const [filter, setFilter] = useState("");
   const { data } = useGoals();
 
-  if (!API_KEY) return <Login />;
+  if (!isAuthenticated()) return <Login />;
   if (data === undefined) return <Center>Loading...</Center>;
 
   const r = new RegExp(filter, "i");

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -1,4 +1,4 @@
-import { USERNAME, API_KEY } from "../auth";
+import { getCredentials } from "../auth";
 import { Goal } from "../services/beeminder";
 import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
 import Controls from "./controls";
@@ -38,6 +38,7 @@ export default function Detail({
   count: number;
 }) {
   const r = sigfigs(g.mathishard[2]);
+  const { username, apiKey } = getCredentials();
 
   return (
     <div
@@ -68,10 +69,10 @@ export default function Detail({
       <div class="detail__header">
         <div>
           <a
-            href={`https://beeminder.com/${USERNAME}/${g.slug}`}
+            href={`https://beeminder.com/${username}/${g.slug}`}
             onClick={(e) => {
               e.preventDefault();
-              window.location.href = beeminderAuthUrl(USERNAME, API_KEY, `https://beeminder.com/${USERNAME}/${g.slug}`);
+              window.location.href = beeminderAuthUrl(username, apiKey, `https://beeminder.com/${username}/${g.slug}`);
             }}
             class="detail__headerText"
           >

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
 import { useIsFetching } from "@tanstack/react-query";
-import { logout, USERNAME, API_KEY } from "../auth";
+import { logout, getCredentials } from "../auth";
 import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
 import queryClient from "../queryClient";
 import "./header.css";
@@ -35,7 +35,8 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Add goal",
     icon: <CirclePlus />,
     onClick: () => {
-      window.location.href = beeminderAuthUrl(USERNAME, API_KEY, "https://beeminder.com/new");
+      const { username, apiKey } = getCredentials();
+      window.location.href = beeminderAuthUrl(username, apiKey, "https://beeminder.com/new");
     },
   },
   {
@@ -49,7 +50,8 @@ const items: (ItemLink | ItemButton)[] = [
         window.alert("Invalid date format. Please use YYYY-MM-DD.");
         return;
       }
-      const url = beeminderAuthUrl(USERNAME, API_KEY, `https://beeminder.com/breaks?start=${start}&finish=${finish}`);
+      const { username, apiKey } = getCredentials();
+      const url = beeminderAuthUrl(username, apiKey, `https://beeminder.com/breaks?start=${start}&finish=${finish}`);
       window.open(url, "_blank", "noopener,noreferrer");
     },
   },
@@ -57,7 +59,8 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Account settings",
     icon: <Settings />,
     onClick: () => {
-      window.location.href = beeminderAuthUrl(USERNAME, API_KEY, "https://beeminder.com/settings/account");
+      const { username, apiKey } = getCredentials();
+      window.location.href = beeminderAuthUrl(username, apiKey, "https://beeminder.com/settings/account");
     },
   },
   {
@@ -74,7 +77,8 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Premium",
     icon: <Gem />,
     onClick: () => {
-      window.location.href = beeminderAuthUrl(USERNAME, API_KEY, "https://www.beeminder.com/premium");
+      const { username, apiKey } = getCredentials();
+      window.location.href = beeminderAuthUrl(username, apiKey, "https://www.beeminder.com/premium");
     },
   },
   {

--- a/src/services/beeminder/index.ts
+++ b/src/services/beeminder/index.ts
@@ -1,4 +1,4 @@
-import { API_KEY } from "../../auth";
+import { getCredentials } from "../../auth";
 
 const API_ROOT = "https://www.beeminder.com/api/v1";
 
@@ -182,13 +182,16 @@ async function api({
   method?: "get" | "post" | "put" | "delete";
   data?: Record<string, unknown>;
 }) {
-  const result = await fetch(`${API_ROOT}${route}?auth_token=${API_KEY}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data),
-  });
+  const result = await fetch(
+    `${API_ROOT}${route}?auth_token=${getCredentials().apiKey}`,
+    {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(data),
+    }
+  );
 
   if (!result.ok) {
     const body = await result.text().catch(() => "");

--- a/src/useGoals.spec.ts
+++ b/src/useGoals.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Mock auth so we can assert logout() without touching localStorage or
 // navigating. `vi.hoisted` defines the spy above the hoisted vi.mock factory.
 const { logout } = vi.hoisted(() => ({ logout: vi.fn() }));
-vi.mock("./auth", () => ({ logout, API_KEY: "test-token" }));
+vi.mock("./auth", () => ({ logout, isAuthenticated: () => true }));
 
 import { handleGoalsError } from "./useGoals";
 import { BeeminderApiError } from "./services/beeminder";

--- a/src/useGoals.ts
+++ b/src/useGoals.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { API_KEY, logout } from "./auth";
+import { isAuthenticated, logout } from "./auth";
 import { getGoals, Goal, BeeminderApiError } from "./services/beeminder";
 
 // The single source of truth for the goals query key. Anything that reads or
@@ -19,7 +19,7 @@ export function handleGoalsError(err: Error) {
 
 export default function useGoals() {
   return useQuery<Goal[], Error>(GOALS_QUERY_KEY, () => getGoals(), {
-    enabled: !!API_KEY,
+    enabled: isAuthenticated(),
     refetchInterval: (d) => (d?.find((g) => g.queued) ? 3000 : 60000),
     refetchIntervalInBackground: false,
     retry: false,


### PR DESCRIPTION
Closes #19.

## Problem

`auth.ts` read `localStorage` once into module-level consts at **import time**:

```ts
export const USERNAME = localStorage.getItem("username") || "";
export const API_KEY = localStorage.getItem("api_key") || "";
```

That meant: anything auth-dependent was hard to test (you had to seed `localStorage` *before* the module was imported); the values went stale until a full page reload; the storage keys/parsing were import-time global state; and there was no way to ask "am I logged in?".

## Change

Rework `auth.ts` into a session module with a small **on-demand** interface — the seam tests can stand in for:

```ts
getCredentials(): { username, apiKey }
isAuthenticated(): boolean
login(username, apiKey)   // unchanged behavior
logout()                  // unchanged behavior
```

Credentials are read when asked for, never captured at import. Consumers updated:

| File | Before | After |
|---|---|---|
| `app.tsx` | `if (!API_KEY)` | `if (!isAuthenticated())` |
| `useGoals.ts` | `enabled: !!API_KEY` | `enabled: isAuthenticated()` |
| `services/beeminder/index.ts` | `?auth_token=${API_KEY}` | `getCredentials().apiKey` per request (fresh token) |
| `detail.tsx` | `USERNAME`/`API_KEY` consts | `getCredentials()` at render |
| `header.tsx` | `USERNAME`/`API_KEY` consts | `getCredentials()` inside each handler |

`login`/`logout` keep their `window.location.href = "/"` redirect (unchanged). Behavior is otherwise preserved — `isAuthenticated()` is exactly the old `!!API_KEY` check.

## Tests

New `src/auth.spec.ts` (7 cases) — now possible because the module is a real seam instead of import-time global state: `getCredentials` (empty / populated), `isAuthenticated` (no key / username-only / with key), and `login`/`logout` persistence + redirect. Also updated `useGoals.spec.ts`'s `./auth` mock to the new interface.

## Verification

- `npm run checkTs` — clean
- `npx vitest run` — 60/60 pass (+8 new)
- `eslint` on changed files — clean (the 3 pre-existing `groupGoals.spec.ts` errors are unrelated and untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored authentication system to dynamically manage session credentials, replacing static configuration with dynamic storage-based approach for improved reliability and flexibility.

* **Tests**
  * Added comprehensive test suite verifying authentication flows, including login persistence, logout clearing, and credential retrieval.

* **Bug Fixes**
  * Enhanced logout behavior with automatic redirect to home page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PinePeakDigital/bm/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->