### PR TITLE
feat(ui): make goal detail page responsive at wide widths

### DIFF
--- a/src/components/detail.css
+++ b/src/components/detail.css
@@ -50,6 +50,24 @@
     padding: var(--padding);
 }
 
+/* On wide screens, lay the graph + pills alongside the data + fineprint
+   instead of stacking the whole thing in a narrow column. align-items:start
+   keeps each column's content top-aligned rather than stretching to match. */
+@media (min-width: 900px) {
+    .detail_info {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: calc(var(--padding) * 2);
+        align-items: start;
+    }
+
+    /* The first heading in the data column already aligns with the top of the
+       graph, so drop its leading margin to keep the two columns level. */
+    .detail__data h2:first-child {
+        margin-top: 0;
+    }
+}
+
 .detail_info p {
     margin: var(--padding) 0;
 }

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -126,52 +126,56 @@ export default function Detail({
       </div>
 
       <div className="detail_info">
-        <img src={g.svg_url} width={230} height={150} />
+        <div class="detail__graph">
+          <img src={g.svg_url} width={230} height={150} />
 
-        <ul class="pills">
-          <li>
-            {r} {g.gunits} / {g.runits}
-          </li>
-          <li>{g.aggday}</li>
-          <li>deadline: {convertDeadlineToTime(g.deadline)}</li>
-          {g.autoratchet && <li>autoratchet: {g.autoratchet}d</li>}
-        </ul>
+          <ul class="pills">
+            <li>
+              {r} {g.gunits} / {g.runits}
+            </li>
+            <li>{g.aggday}</li>
+            <li>deadline: {convertDeadlineToTime(g.deadline)}</li>
+            {g.autoratchet && <li>autoratchet: {g.autoratchet}d</li>}
+          </ul>
+        </div>
 
-        <h2>Recent Data</h2>
+        <div class="detail__data">
+          <h2>Recent Data</h2>
 
-        <table>
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Comment</th>
-              <th>Value</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {g.recent_data.map((point) => (
-              <DatapointRow
-                key={point.id}
-                goal={g.slug}
-                point={{
-                  id: point.id,
-                  daystamp: point.daystamp,
-                  comment: point.comment,
-                  value: point.value,
-                }}
-              />
-            ))}
-          </tbody>
-        </table>
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Comment</th>
+                <th>Value</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {g.recent_data.map((point) => (
+                <DatapointRow
+                  key={point.id}
+                  goal={g.slug}
+                  point={{
+                    id: point.id,
+                    daystamp: point.daystamp,
+                    comment: point.comment,
+                    value: point.value,
+                  }}
+                />
+              ))}
+            </tbody>
+          </table>
 
-        <h2>Fineprint</h2>
+          <h2>Fineprint</h2>
 
-        <div
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: parseFineprint(g.fineprint || ""),
-          }}
-        />
+          <div
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: parseFineprint(g.fineprint || ""),
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/goalPage.css
+++ b/src/components/goalPage.css
@@ -1,9 +1,16 @@
 /* The single-goal page: a centred, readable column rather than the modal's
-   fixed 500px box. */
+   fixed 500px box. On wide screens it grows into a two-column layout (see
+   detail.css) so the graph and data sit side by side instead of stacking. */
 .goalPage {
   max-width: 540px;
   margin: 0 auto;
   padding: var(--padding);
+}
+
+@media (min-width: 900px) {
+  .goalPage {
+    max-width: 1080px;
+  }
 }
 
 .goalPage__back {


### PR DESCRIPTION
## What

Makes the goal detail page use the available horizontal space on larger screens instead of staying in a fixed narrow column.

- **`detail.tsx`** — group the `detail_info` children into two containers: `.detail__graph` (graph + pills) and `.detail__data` (Recent Data table + Fineprint). Pure restructure; no logic changes.
- **`detail.css`** — above `900px`, `.detail_info` becomes a two-column grid (`minmax(0, 1fr) minmax(0, 1fr)`, `align-items: start`), with the data column's first heading top-aligned to the graph.
- **`goalPage.css`** — widen the page container from the fixed `540px` to `1080px` above `900px`. Narrow screens keep the readable `540px` column.

## Layout

- **Wide (≥900px):** graph + pills on the left, Recent Data + Fineprint on the right; header and pager span full width.
- **Narrow (<900px):** unchanged — everything stacks vertically as before.

## Verification

- Confirmed in the running app against a live goal at 1600px and 480px viewports.
- `detail.spec.tsx` passes; `tsc --noEmit` clean; lint clean on touched files.
- Pre-push review loop (6 parallel agents: CLAUDE.md, bugs, git history, comments, security, test coverage) returned zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design on wider displays with improved side-by-side layout for data and graphs.
  * Expanded page width to better utilize larger screen space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->