### PR TITLE
Fold filtering into goalRoster; cover getGroup directly

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -1,25 +1,23 @@
 import { useState } from "preact/hooks";
 import useGoals from "../useGoals";
-import filterGoals from "../lib/filterGoals";
 import { Goals } from "./goals";
 import Header from "./header";
 import Center from "./center";
 
 // The dashboard page: the search/filter header plus the grid of goals. Filter
-// state lives here because it's meaningful only on this page.
+// state lives here because it's meaningful only on this page; the grid hands it
+// to goalRoster, which owns the filter → group → order pipeline.
 export default function Dashboard() {
   const [filter, setFilter] = useState("");
   const { data } = useGoals();
 
   if (data === undefined) return <Center>Loading...</Center>;
 
-  const filtered = filterGoals(data, filter);
-
   return (
     <>
       <Header search={filter} setSearch={setFilter} />
       <div class="app__content">
-        <Goals goals={filtered} />
+        <Goals goals={data} filter={filter} />
       </div>
     </>
   );

--- a/src/components/goalPage.tsx
+++ b/src/components/goalPage.tsx
@@ -20,7 +20,7 @@ export default function GoalPage() {
   const navigate = useNavigate();
   const { data } = useGoals();
 
-  const roster = goalRoster(data ?? [], slug);
+  const roster = goalRoster(data ?? [], { currentSlug: slug });
   const { prev, next, current } = roster;
 
   const goTo = (target: string) => {

--- a/src/components/goals.tsx
+++ b/src/components/goals.tsx
@@ -7,11 +7,15 @@ import "./goals.css";
 
 // The goal grid. Each card is a real link to that goal's page; opening,
 // paging, and closing a goal are all plain navigation now (see goalPage.tsx),
-// so there's no modal or selection state to track here. The rows and their
-// order come from goalRoster — the single source of goal display order, shared
-// with the detail pager so the grid and "prev/next" can't drift.
-export function Goals({ goals }: { goals: Goal[] }) {
-  const { rows } = useMemo(() => goalRoster(goals), [goals]);
+// so there's no modal or selection state to track here. The rows, their order,
+// and the search filtering all come from goalRoster — the single source of goal
+// display order, shared with the detail pager so the grid and "prev/next" can't
+// drift.
+export function Goals({ goals, filter }: { goals: Goal[]; filter?: string }) {
+  const { rows } = useMemo(
+    () => goalRoster(goals, { filter }),
+    [goals, filter]
+  );
 
   return (
     <div class="goals">

--- a/src/lib/getGroup.spec.ts
+++ b/src/lib/getGroup.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { Goal } from "../services/beeminder";
+import { getGroup } from "./getGroup";
+
+function goal(props: Partial<Goal>): Goal {
+  return props as Goal;
+}
+
+// Goals are bucketed by safety buffer (`safebuf`, days of leeway), whether
+// they've been touched today (`todayta`), and whether they're pinned. These
+// tests pin down the thresholds directly rather than through groupGoals.
+describe("getGroup", () => {
+  describe("pinned", () => {
+    it("pins a goal tagged #bmPin regardless of buffer", () => {
+      expect(getGroup(goal({ fineprint: "#bmPin", safebuf: 0 }))).toBe("pinned");
+      expect(getGroup(goal({ fineprint: "#bmPin", safebuf: 30 }))).toBe(
+        "pinned"
+      );
+    });
+
+    it("pins a Beeminder drinker goal", () => {
+      expect(getGroup(goal({ goal_type: "drinker", safebuf: 5 }))).toBe(
+        "pinned"
+      );
+    });
+
+    it("pinning wins over an otherwise-due goal", () => {
+      // safebuf 0 would be "today", but the pin takes precedence.
+      expect(getGroup(goal({ fineprint: "#bmPin", safebuf: 0 }))).toBe("pinned");
+    });
+  });
+
+  describe("today", () => {
+    it("buckets a due goal (safebuf 0) as today", () => {
+      expect(getGroup(goal({ safebuf: 0 }))).toBe("today");
+    });
+  });
+
+  describe("next vs later threshold (LATER_BUFFER_THRESHOLD = 7)", () => {
+    it("an untouched goal just under the threshold is next", () => {
+      expect(getGroup(goal({ safebuf: 1, todayta: false }))).toBe("next");
+      expect(getGroup(goal({ safebuf: 6, todayta: false }))).toBe("next");
+    });
+
+    it("an untouched goal at the threshold is later", () => {
+      // 7 is not < 7, so it tips into later.
+      expect(getGroup(goal({ safebuf: 7, todayta: false }))).toBe("later");
+    });
+
+    it("an untouched goal well past the threshold is later", () => {
+      expect(getGroup(goal({ safebuf: 30, todayta: false }))).toBe("later");
+    });
+  });
+
+  describe("touched goals", () => {
+    it("a touched goal under the threshold is later, not next", () => {
+      // Having logged data today (todayta truthy) keeps it out of the "next"
+      // attention bucket even with a small buffer.
+      expect(getGroup(goal({ safebuf: 3, todayta: true }))).toBe("later");
+    });
+
+    it("a touched goal still counts as today when due", () => {
+      // safebuf 0 is checked before the touched/next logic.
+      expect(getGroup(goal({ safebuf: 0, todayta: true }))).toBe("today");
+    });
+  });
+});

--- a/src/lib/goalRoster.spec.ts
+++ b/src/lib/goalRoster.spec.ts
@@ -14,7 +14,7 @@ function today(slug: string, losedate: number): Goal {
 
 describe("goalRoster", () => {
   it("returns an empty roster for no goals", () => {
-    const roster = goalRoster([], undefined);
+    const roster = goalRoster([]);
     expect(roster.ordered).toEqual([]);
     expect(roster.count).toBe(0);
     expect(roster.index).toBe(-1);
@@ -76,7 +76,7 @@ describe("goalRoster", () => {
 
   it("reports index, count and neighbours for a middle goal", () => {
     const goals = [today("a", 1), today("b", 2), today("c", 3)];
-    const roster = goalRoster(goals, "b");
+    const roster = goalRoster(goals, { currentSlug: "b" });
 
     expect(roster.index).toBe(1);
     expect(roster.count).toBe(3);
@@ -88,11 +88,11 @@ describe("goalRoster", () => {
   it("has no prev at the start and no next at the end", () => {
     const goals = [today("a", 1), today("b", 2), today("c", 3)];
 
-    const first = goalRoster(goals, "a");
+    const first = goalRoster(goals, { currentSlug: "a" });
     expect(first.prev).toBeUndefined();
     expect(first.next?.slug).toBe("b");
 
-    const last = goalRoster(goals, "c");
+    const last = goalRoster(goals, { currentSlug: "c" });
     expect(last.next).toBeUndefined();
     expect(last.prev?.slug).toBe("b");
   });
@@ -101,7 +101,7 @@ describe("goalRoster", () => {
     // Preserves the prior grid behaviour where, with nothing open, advancing
     // ("next") jumps to the first goal.
     const goals = [today("a", 1), today("b", 2)];
-    const roster = goalRoster(goals, undefined);
+    const roster = goalRoster(goals);
 
     expect(roster.index).toBe(-1);
     expect(roster.current).toBeUndefined();
@@ -113,11 +113,73 @@ describe("goalRoster", () => {
     // The goal-detail not-found page routes to a slug string that isn't in the
     // list; it must behave like the empty-slug case rather than throwing.
     const goals = [today("a", 1), today("b", 2)];
-    const roster = goalRoster(goals, "missing-slug");
+    const roster = goalRoster(goals, { currentSlug: "missing-slug" });
 
     expect(roster.index).toBe(-1);
     expect(roster.current).toBeUndefined();
     expect(roster.prev).toBeUndefined();
     expect(roster.next?.slug).toBe("a");
+  });
+
+  describe("filtering pipeline", () => {
+    it("returns every goal when no filter is given (the pager's view)", () => {
+      const goals = [today("alpha", 1), today("beta", 2), today("gamma", 3)];
+      expect(goalRoster(goals).ordered.map((g) => g.slug)).toEqual([
+        "alpha",
+        "beta",
+        "gamma",
+      ]);
+    });
+
+    it("narrows the roster to goals matching the filter before grouping", () => {
+      const goals = [today("run-am", 1), today("run-pm", 2), today("sleep", 3)];
+      const roster = goalRoster(goals, { filter: "run" });
+
+      // "run" matches both run-* goals (regex, case-insensitive); count
+      // reflects the filtered set, not the full list.
+      expect(roster.ordered.map((g) => g.slug)).toEqual(["run-am", "run-pm"]);
+      expect(roster.count).toBe(2);
+    });
+
+    it("groups and orders the filtered set, not the raw input", () => {
+      // Filtering happens first, so a filtered-out "today" goal can't sneak into
+      // the today row or shift the flattened order.
+      const goals = [
+        goal({ slug: "keep-pinned", fineprint: "#bmPin", safebuf: 3, losedate: 4 }),
+        goal({ slug: "drop-today", safebuf: 0, losedate: 1 }),
+        goal({ slug: "keep-later", safebuf: 10, todayta: true, losedate: 5 }),
+      ];
+      const roster = goalRoster(goals, { filter: "keep" });
+
+      expect(roster.ordered.map((g) => g.slug)).toEqual([
+        "keep-pinned",
+        "keep-later",
+      ]);
+      expect(roster.rows.map((r) => r.goals.map((g) => g.slug))).toEqual([
+        ["keep-pinned"],
+        [],
+        ["keep-later"],
+      ]);
+    });
+
+    it("locates the current goal within the filtered set", () => {
+      const goals = [today("run-am", 1), today("run-pm", 2), today("sleep", 3)];
+      // sleep is filtered out, so paging is relative to [run-am, run-pm].
+      const roster = goalRoster(goals, { filter: "run", currentSlug: "run-am" });
+
+      expect(roster.index).toBe(0);
+      expect(roster.count).toBe(2);
+      expect(roster.next?.slug).toBe("run-pm");
+    });
+
+    it("falls back to a literal match for an invalid regex filter", () => {
+      // A lone "(" would throw from new RegExp; filterGoals degrades to a
+      // case-insensitive substring match rather than crashing the roster.
+      const goals = [goal({ slug: "a(b", safebuf: 0, losedate: 1 })];
+      expect(() => goalRoster(goals, { filter: "a(" })).not.toThrow();
+      expect(goalRoster(goals, { filter: "a(" }).ordered.map((g) => g.slug)).toEqual([
+        "a(b",
+      ]);
+    });
   });
 });

--- a/src/lib/goalRoster.ts
+++ b/src/lib/goalRoster.ts
@@ -1,4 +1,5 @@
 import { Goal } from "../services/beeminder";
+import filterGoals from "./filterGoals";
 import groupGoals from "./groupGoals";
 
 export type GoalGroup = "pinned" | "today" | "next" | "later";
@@ -33,14 +34,27 @@ export type GoalRoster = {
   next?: Goal;
 };
 
-// The single definition of how the dashboard lays out and orders goals, and how
-// you move between them. Both the goal grid and the detail pager go through
-// this, so the rendered order and "prev/next"/"X of N" share one ordered list.
+export type GoalRosterOptions = {
+  // Narrow the roster to goals matching the dashboard search box. Omitted or
+  // empty means no filtering — the detail pager walks the full, unfiltered list.
+  filter?: string;
+  // Slug of the goal currently open in the detail pager, if any.
+  currentSlug?: string;
+};
+
+// The single definition of how the dashboard turns the raw goal list into what
+// you see and how you move through it: filter (search box) → classify → group →
+// order → locate the current goal's neighbours. Both the goal grid and the
+// detail pager go through this, so the rendered order, the filtered set, and
+// "prev/next"/"X of N" all share one pipeline and can't drift apart.
 export default function goalRoster(
   goals: Goal[],
-  currentSlug?: string
+  { filter, currentSlug }: GoalRosterOptions = {}
 ): GoalRoster {
-  const grouped = groupGoals(goals);
+  // filterGoals returns the input untouched for an empty filter, so the pager
+  // (which passes no filter) walks every goal.
+  const matched = filterGoals(goals, filter ?? "");
+  const grouped = groupGoals(matched);
   const rows: GoalRow[] = ROWS.map((groups) => ({
     groups,
     goals: groups.flatMap((name) => grouped[name]),


### PR DESCRIPTION
Closes #28.

## Problem

The dashboard's filter → group → order pipeline was split across files and never tested end to end:

```
dashboard.tsx   filterGoals(data, filter)
  -> <Goals goals={filtered} />
       -> goalRoster(goals)   // groups + orders
```

And `getGroup`'s thresholds (`safebuf === 0`, `safebuf < 7`) were only exercised incidentally through `groupGoals`' fixtures — it had no spec of its own.

## Change

`goalRoster` (the deep module introduced in #27) now owns the **whole** pipeline. Its second argument becomes an options object:

```ts
goalRoster(goals, { filter?, currentSlug? })
```

Internally: `filterGoals` → `groupGoals`/`getGroup` (classify) → rows → flattened `ordered` → locate `current`/`prev`/`next`.

- `dashboard.tsx` no longer calls `filterGoals`; it passes the raw list + `filter` to `<Goals>`.
- `goals.tsx` gains a `filter` prop and threads it through.
- `goalPage.tsx` passes `{ currentSlug: slug }` and **no filter**, so the detail pager still walks the full, unfiltered list — behavior unchanged.

`filterGoals`, `getGroup`, and `groupGoals` remain as internal, individually-tested helpers (internal seams); the deepened interface is `goalRoster`.

## Tests

- New `goalRoster` "filtering pipeline" cases: no-filter passthrough, filter narrows before grouping, the filtered set is grouped/ordered correctly, the current goal is located within the filtered set, and an invalid regex degrades to a literal match instead of crashing.
- New `src/lib/getGroup.spec.ts`: pins the next/later boundary (`safebuf` 6 → next, 7 → later), pinned precedence (`#bmPin` and `drinker`), due (`safebuf` 0), and touched → later.

## Behavior

No user-facing change. The dashboard grid filters exactly as before; the pager is unaffected. The undefined-`safebuf` edge noted in #28 is type-impossible (`Goal.safebuf` is a required `number`), so no runtime guard was added.

## Verification

- `vitest run` — 99 tests pass.
- `tsc && vite build` — clean.
- Pre-push review loop (6 parallel agents: CLAUDE.md, bugs, history, comments, security, coverage) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured goal filtering and roster management to improve code organization.
  * Centralized goal filtering logic for enhanced consistency across dashboard and goal components.
  * Updated goal list builder to support integrated filtering and navigation.

* **Tests**
  * Added comprehensive test suite for goal grouping and bucketing behavior.
  * Expanded roster functionality tests to cover filtering and navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->