### PR TITLE
Give the 'processing' (queued) state a single home

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -2,6 +2,7 @@ import "./goal.css";
 import { Goal } from "../services/beeminder";
 import useGoalMutations from "../useGoalMutations";
 import { getAutodata } from "../lib/directives";
+import { isProcessing } from "../lib/goalProcessing";
 import cnx from "../cnx";
 import { useState } from "preact/hooks";
 import "./controls.css";
@@ -31,7 +32,8 @@ export default function Controls({
   const [value, setValue] = useState<string>("");
   const { addDatapoint, refresh: refreshGoal } = useGoalMutations(g.slug);
   const autodata = getAutodata(g);
-  const isLoading = addDatapoint.isLoading || refreshGoal.isLoading || g.queued;
+  const isLoading =
+    addDatapoint.isLoading || refreshGoal.isLoading || isProcessing(g);
   const isError = addDatapoint.isError || refreshGoal.isError;
   const tooltip = isError
     ? getErrorMessage(addDatapoint.error || refreshGoal.error)

--- a/src/lib/goalProcessing.spec.ts
+++ b/src/lib/goalProcessing.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { Goal } from "../services/beeminder";
+import { isProcessing, markProcessing } from "./goalProcessing";
+
+function goal(props: Partial<Goal>): Goal {
+  return props as Goal;
+}
+
+describe("isProcessing", () => {
+  it("is true for a queued goal", () => {
+    expect(isProcessing(goal({ queued: true }))).toBe(true);
+  });
+
+  it("is false for an unqueued goal", () => {
+    expect(isProcessing(goal({ queued: false }))).toBe(false);
+  });
+
+  it("coerces a missing queued flag to false", () => {
+    expect(isProcessing(goal({}))).toBe(false);
+  });
+});
+
+describe("markProcessing", () => {
+  it("marks the goal as processing", () => {
+    expect(markProcessing(goal({ slug: "a", queued: false })).queued).toBe(true);
+  });
+
+  it("does not mutate the original goal", () => {
+    const g = goal({ slug: "a", queued: false });
+    const marked = markProcessing(g);
+
+    expect(g.queued).toBe(false);
+    expect(marked).not.toBe(g);
+  });
+
+  it("preserves the rest of the goal", () => {
+    const marked = markProcessing(goal({ slug: "a", safebuf: 3 }));
+
+    expect(marked.slug).toBe("a");
+    expect(marked.safebuf).toBe(3);
+  });
+});

--- a/src/lib/goalProcessing.ts
+++ b/src/lib/goalProcessing.ts
@@ -1,0 +1,18 @@
+import { Goal } from "../services/beeminder";
+
+// A goal is "processing" while Beeminder works a queued datapoint: the API sets
+// `queued` server-side, and we set it optimistically the moment a mutation
+// fires. This module is the one place that knows that field, so the goals poll
+// interval (which speeds up while anything is processing) and the optimistic
+// cache update can't drift on what "processing" means.
+
+// Whether Beeminder is still working a queued datapoint for this goal.
+export function isProcessing(g: Goal): boolean {
+  return !!g.queued;
+}
+
+// Optimistically mark a goal as processing, before the server confirms. Returns
+// a new goal; never mutates the input.
+export function markProcessing(g: Goal): Goal {
+  return { ...g, queued: true };
+}

--- a/src/useGoalMutations.ts
+++ b/src/useGoalMutations.ts
@@ -4,6 +4,7 @@ import {
 } from "@tanstack/react-query";
 import queryClient from "./queryClient";
 import { GOALS_QUERY_KEY } from "./useGoals";
+import { markProcessing } from "./lib/goalProcessing";
 import {
   createDatapoint,
   deleteDatapoint,
@@ -14,7 +15,7 @@ import {
 type Context = { previous?: Goal[] };
 
 // Every goal mutation behaves the same way around the goals cache:
-//   1. optimistically mark the goal as `queued` so the UI shows it working,
+//   1. optimistically mark the goal as processing so the UI shows it working,
 //   2. roll that back if the mutation fails, and
 //   3. invalidate the goals query once it settles so we refetch the truth.
 //
@@ -28,7 +29,7 @@ export function goalMutationOptions<TVariables>(
       await queryClient.cancelQueries(GOALS_QUERY_KEY);
       const previous = queryClient.getQueryData<Goal[]>(GOALS_QUERY_KEY);
       queryClient.setQueryData<Goal[]>(GOALS_QUERY_KEY, (goals) =>
-        goals?.map((g) => (g.slug === slug ? { ...g, queued: true } : g))
+        goals?.map((g) => (g.slug === slug ? markProcessing(g) : g))
       );
       return { previous };
     },

--- a/src/useGoals.ts
+++ b/src/useGoals.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { isAuthenticated, logout } from "./auth";
 import { getGoals, Goal, BeeminderApiError } from "./services/beeminder";
+import { isProcessing } from "./lib/goalProcessing";
 
 // The single source of truth for the goals query key. Anything that reads or
 // mutates the cached goals list keys off this.
@@ -20,7 +21,7 @@ export function handleGoalsError(err: Error) {
 export default function useGoals() {
   return useQuery<Goal[], Error>(GOALS_QUERY_KEY, () => getGoals(), {
     enabled: isAuthenticated(),
-    refetchInterval: (d) => (d?.find((g) => g.queued) ? 3000 : 60000),
+    refetchInterval: (d) => (d?.some(isProcessing) ? 3000 : 60000),
     refetchIntervalInBackground: false,
     retry: false,
     onError: handleGoalsError,


### PR DESCRIPTION
Closes #29.

## Problem

The "is this goal mid-refresh?" notion was open-coded against Beeminder's `queued` field in three unrelated places, with no single definition:

- `useGoals.ts` — poll interval read `d?.find((g) => g.queued)`
- `useGoalMutations.ts` — optimistic update wrote `{ ...g, queued: true }`
- `controls.tsx` — loading state read `g.queued` directly

## Change

Add `src/lib/goalProcessing.ts` with two functions that own the `queued` field:

- `isProcessing(g)` — whether Beeminder is still working a queued datapoint (the read).
- `markProcessing(g)` — optimistically mark a goal as processing, returning a new goal (the write).

All three call sites now route through it: `useGoals` polls via `some(isProcessing)`, the mutation's optimistic update uses `markProcessing`, and `controls` checks `isProcessing(g)`. "Processing" is now defined once, so polling, optimism, and the loading indicator can't drift.

## Behavior

No user-facing change — every site is a behavior-preserving swap (`!!g.queued` matches the prior truthiness; `markProcessing` produces the identical immutable `{ ...g, queued: true }`).

## Tests

New `goalProcessing.spec.ts` covers `isProcessing` (true/false/missing flag) and `markProcessing` (sets the flag, no mutation of the original, new object, preserves other fields). The existing `useGoalMutations.spec.ts` already exercises the optimistic-update integration.

## Verification

- `vitest run` — 105 tests pass.
- `tsc && vite build` — clean.
- Pre-push review loop (6 parallel agents) — caught the third (`controls.tsx`) call site I'd initially missed; migrated it so the module truly is the single home, re-verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)