### PR TITLE
Extract datapoint value/rate transforms into lib

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -3,6 +3,7 @@ import { Goal } from "../services/beeminder";
 import useGoalMutations from "../useGoalMutations";
 import { getAutodata } from "../lib/directives";
 import { isProcessing } from "../lib/goalProcessing";
+import parseDatapointValue from "../lib/parseDatapointValue";
 import cnx from "../cnx";
 import { useState } from "preact/hooks";
 import "./controls.css";
@@ -12,14 +13,6 @@ function getErrorMessage(error: unknown) {
   if (typeof error === "string") return error;
   if (error instanceof Error) return error.message;
   return JSON.stringify(error);
-}
-
-function parseValue(value: string): number {
-  if (value.includes(":")) {
-    const [hours, minutes] = value.split(":").map(Number);
-    return hours + minutes / 60;
-  }
-  return Number(value);
 }
 
 export default function Controls({
@@ -52,7 +45,7 @@ export default function Controls({
   }) => {
     e.stopPropagation();
     e.preventDefault();
-    const v = parseValue(value);
+    const v = parseDatapointValue(value);
     if (Number.isFinite(v))
       addDatapoint.mutate(v, { onSuccess: () => setValue("") });
   };

--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -3,45 +3,19 @@ import { useState, useEffect } from "preact/hooks";
 import "./countdown.css";
 import { ComponentChildren } from "preact";
 import { Flag, Hourglass, Skull } from "lucide-preact";
-
-const Unit: Record<string, number> = {
-  s: 1,
-  m: 60,
-  h: 60 * 60,
-  d: 60 * 60 * 24,
-  w: 60 * 60 * 24 * 7,
-  y: 60 * 60 * 24 * 365,
-};
-
-function findUnit(n: number): keyof typeof Unit | undefined {
-  return Object.keys(Unit).findLast((u) => n > Unit[u]);
-}
-
-function getSeconds(g: Goal): number {
-  const now = new Date();
-  const then = new Date(g.losedate * 1000);
-  const diff = then.getTime() - now.getTime();
-  return diff / 1000;
-}
-
-function getPrefix(g: Goal): string {
-  const s = g.baremin.includes("-") ? "-" : "";
-  const t = g.baremin.match(/[1-9]?\d:\d\d/)?.[0];
-  const n = g.baremin.match(/(\d+\.?\d?\d?)/)?.[1] || "";
-  return `${s}${t || n} in`;
-}
+import { Unit, findUnit, secondsUntil, getPrefix } from "../lib/countdown";
 
 function W({ children }: { children: ComponentChildren }) {
   return <span class="countdown">{children}</span>;
 }
 
 export default function Countdown({ g }: { g: Goal }) {
-  const [seconds, setSeconds] = useState<number>(getSeconds(g));
+  const [seconds, setSeconds] = useState<number>(secondsUntil(g.losedate));
 
   useEffect(() => {
     const u = findUnit(seconds);
     const n = u ? seconds % Unit[u] : 1;
-    const fn = () => setSeconds(getSeconds(g));
+    const fn = () => setSeconds(secondsUntil(g.losedate));
     const t = setTimeout(fn, n * 1000);
     const h = () => !document.hidden && fn();
     document.addEventListener("visibilitychange", h);
@@ -91,7 +65,7 @@ export default function Countdown({ g }: { g: Goal }) {
 
   return (
     <W>
-      {getPrefix(g)} {Math.floor(+seconds / Unit[u])}
+      {getPrefix(g.baremin)} {Math.floor(+seconds / Unit[u])}
       {u}
     </W>
   );

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -7,6 +7,7 @@ import "./detail.css";
 import DOMPurify from "isomorphic-dompurify";
 import { marked } from "marked";
 import convertDeadlineToTime from "../services/beeminder/convertDeadlineToTime";
+import sigfigs from "../lib/sigfigs";
 import { ArrowLeft, ArrowRight } from "lucide-preact";
 import { ComponentChildren } from "preact";
 import { isPlainLeftClick } from "../lib/viewTransition";
@@ -54,14 +55,6 @@ function parseFineprint(fineprint: string): string {
   if (!fineprint) return "[empty]";
   const html = marked.parse(fineprint);
   return DOMPurify.sanitize(html);
-}
-
-function sigfigs(n: number) {
-  const digits = 2;
-  const isNegative = n < 0;
-  const abs = Math.abs(n);
-  const rounded = Math.round(abs * 10 ** digits) / 10 ** digits;
-  return isNegative ? -rounded : rounded;
 }
 
 export default function Detail({

--- a/src/lib/countdown.spec.ts
+++ b/src/lib/countdown.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { findUnit, secondsUntil, getPrefix } from "./countdown";
+
+describe("findUnit", () => {
+  it("picks the largest unit the duration exceeds", () => {
+    expect(findUnit(30)).toBe("s"); // > 1s, not > 1m
+    expect(findUnit(90)).toBe("m"); // > 1m, not > 1h
+    expect(findUnit(60 * 60 * 25)).toBe("d"); // just over a day
+    expect(findUnit(60 * 60 * 24 * 8)).toBe("w"); // just over a week
+  });
+
+  it("is undefined for under a second", () => {
+    expect(findUnit(0.5)).toBeUndefined();
+    expect(findUnit(0)).toBeUndefined();
+  });
+});
+
+describe("secondsUntil", () => {
+  const now = new Date("2026-01-01T00:00:00Z");
+
+  it("returns the seconds remaining until the losedate", () => {
+    expect(secondsUntil(now.getTime() / 1000 + 120, now)).toBe(120);
+  });
+
+  it("is negative once the losedate has passed", () => {
+    expect(secondsUntil(now.getTime() / 1000 - 60, now)).toBe(-60);
+  });
+});
+
+describe("getPrefix", () => {
+  it("formats a bare number", () => {
+    expect(getPrefix("1")).toBe("1 in");
+    expect(getPrefix("1.5")).toBe("1.5 in");
+  });
+
+  it("prefers an h:mm time over a number", () => {
+    expect(getPrefix("2:30")).toBe("2:30 in");
+  });
+
+  it("keeps a leading minus sign", () => {
+    expect(getPrefix("-3")).toBe("-3 in");
+    expect(getPrefix("-1:15")).toBe("-1:15 in");
+  });
+});

--- a/src/lib/countdown.spec.ts
+++ b/src/lib/countdown.spec.ts
@@ -5,8 +5,10 @@ describe("findUnit", () => {
   it("picks the largest unit the duration exceeds", () => {
     expect(findUnit(30)).toBe("s"); // > 1s, not > 1m
     expect(findUnit(90)).toBe("m"); // > 1m, not > 1h
+    expect(findUnit(60 * 60 * 2)).toBe("h"); // just over an hour
     expect(findUnit(60 * 60 * 25)).toBe("d"); // just over a day
     expect(findUnit(60 * 60 * 24 * 8)).toBe("w"); // just over a week
+    expect(findUnit(60 * 60 * 24 * 366)).toBe("y"); // just over a year
   });
 
   it("is undefined for under a second", () => {
@@ -40,5 +42,9 @@ describe("getPrefix", () => {
   it("keeps a leading minus sign", () => {
     expect(getPrefix("-3")).toBe("-3 in");
     expect(getPrefix("-1:15")).toBe("-1:15 in");
+  });
+
+  it("degrades to a bare ' in' for an empty baremin", () => {
+    expect(getPrefix("")).toBe(" in");
   });
 });

--- a/src/lib/countdown.ts
+++ b/src/lib/countdown.ts
@@ -1,0 +1,37 @@
+import { Goal } from "../services/beeminder";
+
+// The math behind the goal countdown: how long until a goal derails, which time
+// unit to show that in, and the rate prefix parsed from Beeminder's `baremin`.
+// The Countdown component owns only the rendering and the tick scheduling.
+
+// Seconds in each display unit, smallest to largest. Order matters: findUnit
+// walks these in order and picks the largest unit the remaining time exceeds.
+export const Unit: Record<string, number> = {
+  s: 1,
+  m: 60,
+  h: 60 * 60,
+  d: 60 * 60 * 24,
+  w: 60 * 60 * 24 * 7,
+  y: 60 * 60 * 24 * 365,
+};
+
+// The largest unit that `seconds` exceeds, or undefined when under a second.
+export function findUnit(seconds: number): keyof typeof Unit | undefined {
+  return Object.keys(Unit).findLast((u) => seconds > Unit[u]);
+}
+
+// Seconds remaining until a goal's losedate; negative once it has passed.
+// `now` is injectable so the calculation is testable.
+export function secondsUntil(losedate: number, now: Date = new Date()): number {
+  return (losedate * 1000 - now.getTime()) / 1000;
+}
+
+// The rate prefix shown before the countdown, parsed from Beeminder's `baremin`
+// (e.g. "-2:30" → "-2:30 in", "1.5" → "1.5 in"). Keeps a leading minus sign and
+// prefers an "h:mm" time over a bare number.
+export function getPrefix(baremin: Goal["baremin"]): string {
+  const sign = baremin.includes("-") ? "-" : "";
+  const time = baremin.match(/[1-9]?\d:\d\d/)?.[0];
+  const number = baremin.match(/(\d+\.?\d?\d?)/)?.[1] || "";
+  return `${sign}${time || number} in`;
+}

--- a/src/lib/parseDatapointValue.spec.ts
+++ b/src/lib/parseDatapointValue.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import parseDatapointValue from "./parseDatapointValue";
+
+describe("parseDatapointValue", () => {
+  it("parses a plain number", () => {
+    expect(parseDatapointValue("5")).toBe(5);
+    expect(parseDatapointValue("1.5")).toBe(1.5);
+  });
+
+  it("parses an h:mm time as fractional hours", () => {
+    expect(parseDatapointValue("1:30")).toBe(1.5);
+    expect(parseDatapointValue("0:15")).toBe(0.25);
+    expect(parseDatapointValue("2:00")).toBe(2);
+  });
+
+  it("treats an empty hours part as zero", () => {
+    expect(parseDatapointValue(":30")).toBe(0.5);
+  });
+
+  it("returns NaN for unparseable input", () => {
+    expect(parseDatapointValue("abc")).toBeNaN();
+  });
+});

--- a/src/lib/parseDatapointValue.spec.ts
+++ b/src/lib/parseDatapointValue.spec.ts
@@ -17,6 +17,10 @@ describe("parseDatapointValue", () => {
     expect(parseDatapointValue(":30")).toBe(0.5);
   });
 
+  it("treats an empty minutes part as zero (trailing colon)", () => {
+    expect(parseDatapointValue("1:")).toBe(1);
+  });
+
   it("returns NaN for unparseable input", () => {
     expect(parseDatapointValue("abc")).toBeNaN();
   });

--- a/src/lib/parseDatapointValue.ts
+++ b/src/lib/parseDatapointValue.ts
@@ -1,0 +1,10 @@
+// Parse a value typed into the datapoint input. Beeminder "hh:mm" goals accept
+// a clock-style entry ("1:30" → 1.5 hours); everything else is a plain number.
+// Returns NaN for unparseable input, so callers can guard with Number.isFinite.
+export default function parseDatapointValue(value: string): number {
+  if (value.includes(":")) {
+    const [hours, minutes] = value.split(":").map(Number);
+    return hours + minutes / 60;
+  }
+  return Number(value);
+}

--- a/src/lib/sigfigs.spec.ts
+++ b/src/lib/sigfigs.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import sigfigs from "./sigfigs";
+
+describe("sigfigs", () => {
+  it("rounds to two decimal places", () => {
+    expect(sigfigs(1.234)).toBe(1.23);
+    expect(sigfigs(1.236)).toBe(1.24);
+  });
+
+  it("leaves shorter decimals and whole numbers unchanged", () => {
+    expect(sigfigs(1.2)).toBe(1.2);
+    expect(sigfigs(5)).toBe(5);
+  });
+
+  it("preserves the sign of negative numbers", () => {
+    expect(sigfigs(-1.234)).toBe(-1.23);
+  });
+
+  it("rounds zero to zero", () => {
+    expect(sigfigs(0)).toBe(0);
+  });
+});

--- a/src/lib/sigfigs.ts
+++ b/src/lib/sigfigs.ts
@@ -1,0 +1,10 @@
+// Round a number to two decimal places for display, preserving sign. (Despite
+// the name this rounds to a fixed number of decimal places, not significant
+// figures — kept as-is to match how the goal rate has always been shown.)
+export default function sigfigs(n: number): number {
+  const digits = 2;
+  const isNegative = n < 0;
+  const abs = Math.abs(n);
+  const rounded = Math.round(abs * 10 ** digits) / 10 ** digits;
+  return isNegative ? -rounded : rounded;
+}


### PR DESCRIPTION
Closes #30. Follow-up for the dead `Time` component: #35.

## Problem

Several pure Beeminder value/rate transforms lived as local functions inside live components, so the only way to exercise them was to render the component and read the DOM — and most had no isolated tests.

## Change

Extracted them into focused `src/lib` modules (beside `directives.ts` and `convertDeadlineToTime.ts`), each with its own spec. Components now render and schedule; the lib owns the math.

| From | To |
| --- | --- |
| `controls.tsx` `parseValue` | `src/lib/parseDatapointValue.ts` |
| `detail.tsx` `sigfigs` | `src/lib/sigfigs.ts` |
| `countdown.tsx` `Unit` / `findUnit` / `getSeconds` / `getPrefix` | `src/lib/countdown.ts` |

Two small interface improvements for testability/focus:
- `getSeconds(g)` → `secondsUntil(losedate, now?)` — pure, with an injectable clock.
- `getPrefix(g)` → `getPrefix(baremin)` — takes only the field it reads.

## Behavior

No user-facing change — every extraction is behavior-preserving (function bodies moved verbatim; `secondsUntil` is arithmetically identical to the old `getSeconds`). Verified by the bug-scan and git-history review agents, including that the deliberate prior fixes (negative-rate `sigfigs`, `findLast` render-reduction, hh:mm parsing) are intact.

## Tests

New direct specs: `parseDatapointValue` (number, h:mm, empty parts, NaN), `sigfigs` (rounding up/down, sign, zero), `countdown` (`findUnit` boundaries incl. hour/year, `secondsUntil` future/past, `getPrefix` number/time/minus/empty). The existing `countdown.spec.tsx` still covers the component rendering path. A `parseValue`/`getPrefix` regression now fails a unit test instead of only surfacing as wrong text in JSX.

## Out of scope

`time.tsx`'s `makePoints`/`makePoint`/`formatNow` were named in #30, but that component is **unused** (no imports, no `<Time>`). Extracting and testing logic for an unrendered view would gold-plate dead code, so I left it and filed **#35** to either delete it or wire it up (and extract then).

## Verification

- `vitest run` — 122 tests pass.
- `tsc && vite build` — clean.
- Pre-push review loop (6 parallel agents) — clean; auto-applied three low-risk boundary-coverage test additions (year/hour `findUnit`, empty `getPrefix`, trailing-colon `parseDatapointValue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)