### PR TITLE
Source credentials inside beeminderAuthUrl

### DIFF
--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -78,7 +78,9 @@ export default function Detail({
   count: number;
 }) {
   const r = sigfigs(g.mathishard[2]);
-  const { username, apiKey } = getCredentials();
+  // Only the username is needed here, to build the visible goal-page URL; the
+  // auth token stays inside beeminderAuthUrl.
+  const { username } = getCredentials();
 
   return (
     <div
@@ -106,7 +108,9 @@ export default function Detail({
             href={`https://beeminder.com/${username}/${g.slug}`}
             onClick={(e) => {
               e.preventDefault();
-              window.location.href = beeminderAuthUrl(username, apiKey, `https://beeminder.com/${username}/${g.slug}`);
+              window.location.href = beeminderAuthUrl(
+                `https://beeminder.com/${username}/${g.slug}`
+              );
             }}
             class="detail__headerText"
           >

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
 import { useIsFetching } from "@tanstack/react-query";
-import { logout, getCredentials } from "../auth";
+import { logout } from "../auth";
 import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
 import queryClient from "../queryClient";
 import "./header.css";
@@ -35,8 +35,7 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Add goal",
     icon: <CirclePlus />,
     onClick: () => {
-      const { username, apiKey } = getCredentials();
-      window.location.href = beeminderAuthUrl(username, apiKey, "https://beeminder.com/new");
+      window.location.href = beeminderAuthUrl("https://beeminder.com/new");
     },
   },
   {
@@ -50,8 +49,9 @@ const items: (ItemLink | ItemButton)[] = [
         window.alert("Invalid date format. Please use YYYY-MM-DD.");
         return;
       }
-      const { username, apiKey } = getCredentials();
-      const url = beeminderAuthUrl(username, apiKey, `https://beeminder.com/breaks?start=${start}&finish=${finish}`);
+      const url = beeminderAuthUrl(
+        `https://beeminder.com/breaks?start=${start}&finish=${finish}`
+      );
       window.open(url, "_blank", "noopener,noreferrer");
     },
   },
@@ -59,8 +59,9 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Account settings",
     icon: <Settings />,
     onClick: () => {
-      const { username, apiKey } = getCredentials();
-      window.location.href = beeminderAuthUrl(username, apiKey, "https://beeminder.com/settings/account");
+      window.location.href = beeminderAuthUrl(
+        "https://beeminder.com/settings/account"
+      );
     },
   },
   {
@@ -77,8 +78,7 @@ const items: (ItemLink | ItemButton)[] = [
     name: "Premium",
     icon: <Gem />,
     onClick: () => {
-      const { username, apiKey } = getCredentials();
-      window.location.href = beeminderAuthUrl(username, apiKey, "https://www.beeminder.com/premium");
+      window.location.href = beeminderAuthUrl("https://www.beeminder.com/premium");
     },
   },
   {

--- a/src/lib/beeminderAuthUrl.spec.ts
+++ b/src/lib/beeminderAuthUrl.spec.ts
@@ -1,48 +1,54 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// beeminderAuthUrl now sources credentials from the session module itself, so
+// callers no longer thread username/apiKey in. Mock getCredentials to drive the
+// inputs. `vi.hoisted` defines the spy above the hoisted vi.mock factory.
+const { getCredentials } = vi.hoisted(() => ({ getCredentials: vi.fn() }));
+vi.mock("../auth", () => ({ getCredentials }));
+
 import { beeminderAuthUrl } from "./beeminderAuthUrl";
 
 describe("beeminderAuthUrl", () => {
+  beforeEach(() => {
+    getCredentials.mockReturnValue({ username: "alice", apiKey: "abc123" });
+  });
+
   it("constructs an auth redirect URL for a beeminder goal page", () => {
-    const url = beeminderAuthUrl(
-      "alice",
-      "abc123",
-      "https://beeminder.com/alice/mygoal"
-    );
-    expect(url).toBe(
+    expect(beeminderAuthUrl("https://beeminder.com/alice/mygoal")).toBe(
       "https://www.beeminder.com/api/v1/users/alice.json?auth_token=abc123&redirect_to_url=https%3A%2F%2Fbeeminder.com%2Falice%2Fmygoal"
     );
   });
 
   it("encodes query parameters in the target URL", () => {
-    const url = beeminderAuthUrl(
-      "alice",
-      "abc123",
-      "https://beeminder.com/breaks?start=2024-01-01&finish=2024-01-07"
-    );
-    expect(url).toBe(
+    expect(
+      beeminderAuthUrl(
+        "https://beeminder.com/breaks?start=2024-01-01&finish=2024-01-07"
+      )
+    ).toBe(
       "https://www.beeminder.com/api/v1/users/alice.json?auth_token=abc123&redirect_to_url=https%3A%2F%2Fbeeminder.com%2Fbreaks%3Fstart%3D2024-01-01%26finish%3D2024-01-07"
     );
   });
 
   it("works for settings pages", () => {
-    const url = beeminderAuthUrl(
-      "alice",
-      "abc123",
-      "https://beeminder.com/settings/account"
-    );
-    expect(url).toBe(
+    expect(beeminderAuthUrl("https://beeminder.com/settings/account")).toBe(
       "https://www.beeminder.com/api/v1/users/alice.json?auth_token=abc123&redirect_to_url=https%3A%2F%2Fbeeminder.com%2Fsettings%2Faccount"
     );
   });
 
-  it("encodes reserved characters in the API key", () => {
-    const url = beeminderAuthUrl(
-      "alice",
-      "key+with=special&chars",
-      "https://beeminder.com/alice/mygoal"
-    );
-    expect(url).toBe(
+  it("encodes reserved characters in the API key sourced from the session", () => {
+    getCredentials.mockReturnValue({
+      username: "alice",
+      apiKey: "key+with=special&chars",
+    });
+
+    expect(beeminderAuthUrl("https://beeminder.com/alice/mygoal")).toBe(
       "https://www.beeminder.com/api/v1/users/alice.json?auth_token=key%2Bwith%3Dspecial%26chars&redirect_to_url=https%3A%2F%2Fbeeminder.com%2Falice%2Fmygoal"
     );
+  });
+
+  it("sources credentials from the session module rather than taking them as arguments", () => {
+    beeminderAuthUrl("https://beeminder.com/new");
+
+    expect(getCredentials).toHaveBeenCalled();
   });
 });

--- a/src/lib/beeminderAuthUrl.ts
+++ b/src/lib/beeminderAuthUrl.ts
@@ -1,7 +1,10 @@
-export function beeminderAuthUrl(
-  username: string,
-  apiKey: string,
-  targetUrl: string
-): string {
+import { getCredentials } from "../auth";
+
+// Build an authenticated deep-link into Beeminder: the API endpoint logs the
+// user in with their stored token and redirects to `targetUrl`. Credentials are
+// sourced from the session module here, so callers (and the views) just say
+// where they want to go and never touch the credential shape themselves.
+export function beeminderAuthUrl(targetUrl: string): string {
+  const { username, apiKey } = getCredentials();
   return `https://www.beeminder.com/api/v1/users/${encodeURIComponent(username)}.json?auth_token=${encodeURIComponent(apiKey)}&redirect_to_url=${encodeURIComponent(targetUrl)}`;
 }


### PR DESCRIPTION
Closes #31.

## Problem

`beeminderAuthUrl(username, apiKey, target)` took raw credentials, so six call sites across `header.tsx` and `detail.tsx` each reached into `getCredentials()` and threaded the auth token in. The whole point of `auth.ts` is to be the **only** place that knows where credentials live — and that knowledge (including the token) had leaked back out into the views.

## Change

`beeminderAuthUrl(targetUrl)` now sources credentials from the session module itself. Callers just say where they want to go:

```ts
// before
const { username, apiKey } = getCredentials();
window.location.href = beeminderAuthUrl(username, apiKey, "https://beeminder.com/new");
// after
window.location.href = beeminderAuthUrl("https://beeminder.com/new");
```

- `header.tsx` drops its `getCredentials` import entirely (all four menu links shrink to one argument).
- `detail.tsx` keeps only `username` — it still needs it for the *visible* goal-page URL (`beeminder.com/<username>/<slug>`) — but no longer handles the auth token at all.

## Behavior & security

The produced URL is **byte-for-byte identical** to before (same template, same `encodeURIComponent` on username/token/target). No new token exposure — in fact fewer components now touch the secret. The prior fixes (apiKey encoding, the Add-breaks date validation, `window.open(..., "noopener,noreferrer")`) are all preserved.

## Tests

`beeminderAuthUrl.spec.ts` now mocks `getCredentials` (idiomatic here — `useGoals.spec.ts` does the same). All four original encoding assertions are preserved, plus a new one verifying credentials are sourced internally rather than passed.

## Verification

- `vitest run` — 123 tests pass.
- `tsc && vite build` — clean.
- Pre-push review loop (6 parallel agents) — no findings; confirmed URL identity, all call sites migrated, no reverted fixes, reduced credential surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)