### PR TITLE
Correct README: goal detail is a routed page, not a modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A modern web dashboard for tracking and managing your [Beeminder](https://www.be
   - **Next**: Upcoming goals
   - **Later**: Future goals
 - **Smart Filtering**: Search goals by slug/name
-- **Detail View**: Click any goal to see detailed information in a modal
-- **Keyboard Navigation**: 
+- **Detail View**: Click any goal to open a dedicated detail page with its own shareable URL; the browser Back button returns you to the dashboard
+- **Keyboard Navigation** (on a goal's detail page):
   - `a` - Navigate to previous goal
   - `d` - Navigate to next goal
-  - `Escape` - Close modal
+  - `Escape` - Return to the dashboard
 - **Real-time Updates**: Automatically refreshes when goals are queued (every 3 seconds) or periodically (every 60 seconds)
 - **Datapoint Management**: Create and delete datapoints directly from the interface
 


### PR DESCRIPTION
## Problem

The README's **Detail View** and **Keyboard Navigation** sections described the goal detail as a *modal*, but it's been a routed page (`/goal/$slug`) with a shareable URL and working Back button for a while now — `router.tsx` even comments that it's a page "rather than a modal over the dashboard." The docs predate that change.

## Change

- "Click any goal to see detailed information in a modal" → a dedicated detail page with its own shareable URL (Back returns to the dashboard).
- `Escape` - "Close modal" → "Return to the dashboard" (matches `goalKeyAction`, which maps Escape to the `dashboard` action).
- Clarified the keyboard shortcuts apply on a goal's detail page.

## Accuracy of the rest

I checked the other concrete claims against the code while here, and they're correct — dev port `5174` (`vite.config.ts`), deploy URL `bm.taskratchet.com` (CNAME + `render.yaml`), the `a`/`d`/`Escape` keys, the 3s/60s refetch intervals, and all the documented scripts. Only the modal wording was stale.

Docs-only; no code, build, or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)