### PR TITLE
style: restyle filter box as a cohesive search field

### DIFF
--- a/src/components/app.css
+++ b/src/components/app.css
@@ -129,13 +129,34 @@ button {
 .filter {
   display: flex;
   align-items: center;
-  font-size: 0.6rem;
+  gap: 0.4rem;
+  padding: 0.3rem 0.5rem;
+  background-color: rgb(29, 29, 29);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 5px;
+}
+
+.filter:focus-within {
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.filter__icon {
+  flex: 0 0 auto;
+  opacity: 0.5;
 }
 
 .filter input {
-  margin-right: 0.4rem;
   flex: 1 0 0;
   min-width: 0;
+}
+
+.filter .filter__clear {
+  flex: 0 0 auto;
+  opacity: 0.6;
+}
+
+.filter .filter__clear:hover {
+  opacity: 1;
 }
 
 .tags {

--- a/src/components/app.css
+++ b/src/components/app.css
@@ -136,8 +136,12 @@ button {
   border-radius: 5px;
 }
 
+/* The input drops its own outline (header.css) so the whole field reads as one
+   control; the field itself takes over the focus indicator with a brighter
+   border and a soft ring, keeping focus clearly visible on the dark frame. */
 .filter:focus-within {
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
 }
 
 .filter__icon {

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -4,7 +4,9 @@
 }
 
 .main-header input {
-    background-color: rgb(29, 29, 29);
+    background-color: transparent;
+    border: none;
+    outline: none;
     color: var(--input-text-color);
 }
 

--- a/src/components/header.spec.tsx
+++ b/src/components/header.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/preact";
+
+// Header calls useIsFetching, a react-query hook whose runtime needs the
+// preact/compat React alias that isn't wired up under vitest. Stub just that
+// hook (keeping the rest of the module, so queryClient.ts still gets a real
+// QueryClient on import) rather than standing up a QueryClientProvider.
+vi.mock("@tanstack/react-query", async (importActual) => ({
+  ...(await importActual<typeof import("@tanstack/react-query")>()),
+  useIsFetching: () => 0,
+}));
+
+import Header from "./header";
+
+describe("Header filter clear button", () => {
+  it("hides the clear button when the filter is empty", () => {
+    const { container } = render(<Header search="" setSearch={() => undefined} />);
+    expect(container.querySelector(".filter__clear")).toBeNull();
+  });
+
+  it("shows the clear button and resets the filter when it has text", () => {
+    const setSearch = vi.fn();
+    const { container } = render(
+      <Header search="weight" setSearch={setSearch} />
+    );
+
+    const clear = container.querySelector(".filter__clear");
+    expect(clear).not.toBeNull();
+
+    fireEvent.click(clear as Element);
+    expect(setSearch).toHaveBeenCalledWith("");
+  });
+});

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,6 +11,7 @@ import {
   LogOut,
   Newspaper,
   RefreshCw,
+  Search,
   Settings,
   TreePalm,
   X,
@@ -107,15 +108,22 @@ export default function Header({
     <div class="main-header">
       <div class="global-controls">
         <span class="filter">
+          <Search class="filter__icon" />
           <input
             type="text"
             placeholder="filter"
             value={search}
             onChange={(e) => setSearch(e.currentTarget.value)}
           />
-          <button class="icon-button" onClick={() => setSearch("")}>
-            <X />
-          </button>
+          {search && (
+            <button
+              class="icon-button filter__clear"
+              onClick={() => setSearch("")}
+              title="Clear filter"
+            >
+              <X />
+            </button>
+          )}
         </span>
 
         <span class="buttons">


### PR DESCRIPTION
## What

Restyles the dashboard filter box to match the rest of the app.

- The filter input is now a **rounded dark search pill** — `5px` radius and `rgb(29,29,29)` background matching the app's dark frame and goal-page surfaces — with a subtle `1px` border, replacing the raw dark input with a browser-default border and a tiny `0.6rem` wrapper font.
- Added a **leading search icon** (lucide `Search`), fitting the icon-driven header.
- The **clear (✕) button now appears only when there's text** (previously always rendered).
- The input is transparent inside the field, with a `:focus-within` indicator (brighter border + soft ring) since the input drops its own outline.

## Testing

- Added `header.spec.tsx` covering the conditionally-rendered clear button (hidden when empty; shown + calls `setSearch("")` on click).
- Full suite green (125 tests), `tsc --noEmit` clean.
- Verified visually by reproducing the exact markup + CSS and screenshotting the empty and filled states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)