### PR TITLE
Global nav drawer + "How bm works" docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A modern web dashboard for tracking and managing your [Beeminder](https://www.be
   - `Escape` - Return to the dashboard
 - **Real-time Updates**: Automatically refreshes when goals are queued (every 3 seconds) or periodically (every 60 seconds)
 - **Datapoint Management**: Create and delete datapoints directly from the interface
+- **Navigation Drawer**: Rarely-used actions (add goal, breaks, account settings, Beeminder links, logout) live in a slide-out drawer behind the ☰ button, available on every page
+- **In-app Docs**: A "How bm works" page documenting goal groups, keyboard navigation, and the `#bm` fineprint tags (`#bmPin`, `#bmAutodata=<url>`); reachable from the drawer and footer
 
 ## Tech Stack
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,14 +5,17 @@ import { isAuthenticated } from "../auth";
 import Login from "./login";
 import queryClient from "../queryClient";
 import Footer from "./footer";
+import NavDrawer from "./navDrawer";
 
-// The persistent app shell: the dark frame and footer that wrap every page. The
-// active page (dashboard or a single goal) renders into the <Outlet/>.
+// The persistent app shell: the dark frame, global nav drawer, and footer that
+// wrap every page. The active page (dashboard, a single goal, or the docs page)
+// renders into the <Outlet/>.
 function Layout() {
   if (!isAuthenticated()) return <Login />;
 
   return (
     <div class={`app__base app__dark`}>
+      <NavDrawer />
       <Outlet />
       <Footer />
     </div>

--- a/src/components/docsPage.css
+++ b/src/components/docsPage.css
@@ -1,0 +1,37 @@
+/* A centred, readable prose column — same width and back-link treatment as the
+   single-goal page (see goalPage.css) so the two routed pages feel of a piece. */
+.docs {
+  max-width: 540px;
+  margin: 0 auto;
+  padding: var(--padding);
+  line-height: 1.5;
+}
+
+.docs__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-bottom: var(--padding);
+  font-size: 0.9rem;
+}
+
+.docs h1 {
+  font-size: 1.6rem;
+}
+
+.docs h2 {
+  font-size: 1.2rem;
+  margin-top: 1.5rem;
+}
+
+.docs code,
+.docs kbd {
+  background: rgba(128, 128, 128, 0.25);
+  border-radius: 3px;
+  padding: 0.05rem 0.3rem;
+  font-size: 0.85em;
+}
+
+.docs td code {
+  white-space: nowrap;
+}

--- a/src/components/docsPage.css
+++ b/src/components/docsPage.css
@@ -1,5 +1,6 @@
-/* A centred, readable prose column — same width and back-link treatment as the
-   single-goal page (see goalPage.css) so the two routed pages feel of a piece. */
+/* A centred, readable prose column, same width as the single-goal page (see
+   goalPage.css) so the two routed pages feel of a piece. The back link, though,
+   sits at the viewport edge rather than indented into the column. */
 .docs {
   max-width: 540px;
   margin: 0 auto;
@@ -7,11 +8,13 @@
   line-height: 1.5;
 }
 
+/* The back link sits at the viewport's left edge, outside the centred prose
+   column, so it reads as page-level navigation rather than part of the article. */
 .docs__back {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  margin-bottom: var(--padding);
+  margin: var(--padding);
   font-size: 0.9rem;
 }
 

--- a/src/components/docsPage.spec.tsx
+++ b/src/components/docsPage.spec.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/preact";
+
+// ViewLink needs a router context; the back link's target isn't what we're
+// testing here, so stub it to a plain anchor.
+vi.mock("./viewLink", () => ({
+  default: ({ children }: { children: unknown }) => <a>{children as never}</a>,
+}));
+
+import DocsPage from "./docsPage";
+
+describe("DocsPage", () => {
+  it("documents the fineprint tags", () => {
+    const { container } = render(<DocsPage />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("How bm works");
+    expect(text).toContain("#bmPin");
+    expect(text).toContain("#bmAutodata");
+  });
+});

--- a/src/components/docsPage.tsx
+++ b/src/components/docsPage.tsx
@@ -1,0 +1,116 @@
+import { ArrowLeft } from "lucide-preact";
+import ViewLink from "./viewLink";
+import "./docsPage.css";
+
+// The in-app user guide. bm's behaviour — how goals get grouped, what the
+// keyboard does, and especially the `#bm` fineprint tags — lives in code
+// (lib/getGroup.ts, lib/goalKeyAction.ts, lib/directives.ts) and was previously
+// undocumented anywhere a user could see it. This page is the canonical
+// human-facing reference; keep it in sync with those modules.
+export default function DocsPage() {
+  return (
+    <div class="app__content">
+      <div class="docs">
+        <ViewLink to="/" class="docs__back icon-button">
+          <ArrowLeft /> <span>Dashboard</span>
+        </ViewLink>
+
+        <h1>How bm works</h1>
+        <p>
+          <strong>bm</strong> is a focused dashboard for your{" "}
+          <a href="https://www.beeminder.com" target="_blank" rel="noreferrer">
+            Beeminder
+          </a>{" "}
+          goals. It reads your goals through the Beeminder API and reorganises
+          them around one question: <em>what needs my attention?</em>
+        </p>
+
+        <h2>Goal groups</h2>
+        <p>
+          Every goal is sorted into one of four groups, shown in this order:
+        </p>
+        <ul>
+          <li>
+            <strong>Pinned</strong> — goals you always want on top: Beeminder
+            "drinker" goals, or any goal tagged <code>#bmPin</code> (see below).
+          </li>
+          <li>
+            <strong>Today</strong> — goals due today (no safety buffer left).
+          </li>
+          <li>
+            <strong>Next</strong> — goals you haven't entered data for today that
+            run out of buffer within a week.
+          </li>
+          <li>
+            <strong>Later</strong> — everything else, with comfortable buffer.
+          </li>
+        </ul>
+
+        <h2>Keyboard navigation</h2>
+        <p>On a goal's detail page:</p>
+        <ul>
+          <li>
+            <kbd>a</kbd> — previous goal
+          </li>
+          <li>
+            <kbd>d</kbd> — next goal
+          </li>
+          <li>
+            <kbd>Esc</kbd> — back to the dashboard
+          </li>
+        </ul>
+
+        <h2>Fineprint tags</h2>
+        <p>
+          bm stores its own per-goal settings inside each goal's Beeminder{" "}
+          <strong>fineprint</strong> field, encoded as <code>#bm…</code> tokens.
+          A token has to stand on its own (start of the fineprint or after a
+          space) — <code>foo#bmPin</code> doesn't count. You edit the fineprint
+          on the goal's page in Beeminder; bm picks the tags up on its next
+          refresh.
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Tag</th>
+              <th>Effect</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <code>#bmPin</code>
+              </td>
+              <td>
+                Pins the goal to the <strong>Pinned</strong> group, regardless of
+                how much buffer it has.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <code>#bmAutodata=&lt;url&gt;</code>
+              </td>
+              <td>
+                Marks the goal as autodata and gives bm a custom URL to open when
+                you refresh its data — e.g.{" "}
+                <code>#bmAutodata=https://example.com/refresh</code>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          Beeminder "drinker" goals are treated as pinned automatically, so you
+          don't need <code>#bmPin</code> on them.
+        </p>
+
+        <h2>Data &amp; refresh</h2>
+        <p>
+          bm authenticates with your Beeminder username and API token, kept in
+          your browser's local storage — nothing is sent anywhere but Beeminder.
+          Goals refresh automatically (more often while data is queued), and the
+          refresh button in the dashboard header forces an immediate reload.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docsPage.tsx
+++ b/src/components/docsPage.tsx
@@ -10,11 +10,11 @@ import "./docsPage.css";
 export default function DocsPage() {
   return (
     <div class="app__content">
-      <div class="docs">
-        <ViewLink to="/" class="docs__back icon-button">
-          <ArrowLeft /> <span>Dashboard</span>
-        </ViewLink>
+      <ViewLink to="/" class="docs__back icon-button">
+        <ArrowLeft /> <span>Dashboard</span>
+      </ViewLink>
 
+      <div class="docs">
         <h1>How bm works</h1>
         <p>
           <strong>bm</strong> is a focused dashboard for your{" "}
@@ -31,15 +31,17 @@ export default function DocsPage() {
         </p>
         <ul>
           <li>
-            <strong>Pinned</strong> — goals you always want on top: Beeminder
-            "drinker" goals, or any goal tagged <code>#bmPin</code> (see below).
+            <strong>Pinned</strong> — goals you always want on top. Do Less goals
+            (Beeminder's "drinker" type) are pinned automatically; any other goal
+            joins them when you tag it <code>#bmPin</code> (see below). This group
+            is about goal type and your tags, not buffer.
           </li>
           <li>
             <strong>Today</strong> — goals due today (no safety buffer left).
           </li>
           <li>
             <strong>Next</strong> — goals you haven't entered data for today that
-            run out of buffer within a week.
+            have less than one week of buffer.
           </li>
           <li>
             <strong>Later</strong> — everything else, with comfortable buffer.
@@ -82,8 +84,9 @@ export default function DocsPage() {
                 <code>#bmPin</code>
               </td>
               <td>
-                Pins the goal to the <strong>Pinned</strong> group, regardless of
-                how much buffer it has.
+                Pins the goal to the <strong>Pinned</strong> group, the same
+                group Do Less goals land in automatically, so it sorts to the top
+                regardless of its deadline.
               </td>
             </tr>
             <tr>
@@ -91,16 +94,17 @@ export default function DocsPage() {
                 <code>#bmAutodata=&lt;url&gt;</code>
               </td>
               <td>
-                Marks the goal as autodata and gives bm a custom URL to open when
-                you refresh its data — e.g.{" "}
-                <code>#bmAutodata=https://example.com/refresh</code>.
+                Marks the goal as autodata and gives bm a custom URL to request
+                when you refresh the goal — bm sends a fetch to that URL (to kick
+                off your own data sync) instead of refreshing Beeminder's native
+                graph. E.g. <code>#bmAutodata=https://example.com/refresh</code>.
               </td>
             </tr>
           </tbody>
         </table>
         <p>
-          Beeminder "drinker" goals are treated as pinned automatically, so you
-          don't need <code>#bmPin</code> on them.
+          Do Less goals (Beeminder's "drinker" type) are pinned automatically, so
+          you don't need <code>#bmPin</code> on them.
         </p>
 
         <h2>Data &amp; refresh</h2>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,5 @@
 import { ComponentChildren } from "preact";
+import ViewLink from "./viewLink";
 import "./footer.css";
 
 const LINKS = {
@@ -21,7 +22,8 @@ export default function Footer() {
     <small class="footer">
       Made by <Link href={LINKS.na}>Narthur</Link> and{" "}
       <Link href={LINKS.pp}>Pine Peak Digital</Link>.{" "}
-      <Link href={LINKS.bm}>View source</Link>. See also:{" "}
+      <Link href={LINKS.bm}>View source</Link>.{" "}
+      <ViewLink to="/docs">How bm works</ViewLink>. See also:{" "}
       <Link href={LINKS.tr}>TaskRatchet</Link>
     </small>
   );

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -3,6 +3,12 @@
     --input-text-color: white;
 }
 
+/* Leave room on the right for the NavDrawer's fixed hamburger trigger so the
+   refresh button doesn't sit underneath it. */
+.main-header .global-controls {
+    padding-right: 2.25rem;
+}
+
 .main-header input {
     background-color: transparent;
     border: none;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,100 +1,11 @@
 import { useIsFetching } from "@tanstack/react-query";
-import { logout } from "../auth";
-import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
 import queryClient from "../queryClient";
 import "./header.css";
-import { JSX } from "preact/jsx-runtime";
-import {
-  CirclePlus,
-  Gem,
-  LifeBuoy,
-  LogOut,
-  Newspaper,
-  RefreshCw,
-  Search,
-  Settings,
-  TreePalm,
-  X,
-} from "lucide-preact";
+import { RefreshCw, Search, X } from "lucide-preact";
 
-type Item = {
-  name: string;
-  icon: string | JSX.Element;
-  getClasses?: (isFetching: number) => string;
-};
-
-type ItemLink = Item & {
-  url: string;
-};
-
-type ItemButton = Item & {
-  onClick: () => void;
-};
-
-const items: (ItemLink | ItemButton)[] = [
-  {
-    name: "Add goal",
-    icon: <CirclePlus />,
-    onClick: () => {
-      window.location.href = beeminderAuthUrl("https://beeminder.com/new");
-    },
-  },
-  {
-    name: "Add breaks",
-    icon: <TreePalm />,
-    onClick: () => {
-      const start = window.prompt("Start date (YYYY-MM-DD)") || "";
-      const finish = window.prompt("Finish date (YYYY-MM-DD)") || "";
-      const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-      if (!datePattern.test(start) || !datePattern.test(finish)) {
-        window.alert("Invalid date format. Please use YYYY-MM-DD.");
-        return;
-      }
-      const url = beeminderAuthUrl(
-        `https://beeminder.com/breaks?start=${start}&finish=${finish}`
-      );
-      window.open(url, "_blank", "noopener,noreferrer");
-    },
-  },
-  {
-    name: "Account settings",
-    icon: <Settings />,
-    onClick: () => {
-      window.location.href = beeminderAuthUrl(
-        "https://beeminder.com/settings/account"
-      );
-    },
-  },
-  {
-    name: "Blog",
-    icon: <Newspaper />,
-    url: "https://blog.beeminder.com/",
-  },
-  {
-    name: "Docs",
-    icon: <LifeBuoy />,
-    url: "https://help.beeminder.com/",
-  },
-  {
-    name: "Premium",
-    icon: <Gem />,
-    onClick: () => {
-      window.location.href = beeminderAuthUrl("https://www.beeminder.com/premium");
-    },
-  },
-  {
-    name: "Logout",
-    icon: <LogOut />,
-    onClick: logout,
-  },
-  {
-    name: "Refresh",
-    icon: <RefreshCw />,
-    onClick: () => void queryClient.refetchQueries(),
-    getClasses: (isFetching) => (isFetching ? "spin" : ""),
-  },
-];
-
+// The dashboard's header keeps only the two frequent, dashboard-specific
+// controls: the goal filter and a manual refresh. Everything rarer (add goal,
+// breaks, account, docs, logout, …) now lives in the global NavDrawer.
 export default function Header({
   search,
   setSearch,
@@ -127,22 +38,13 @@ export default function Header({
         </span>
 
         <span class="buttons">
-          {items.map((item) => {
-            const props = {
-              key: item.name,
-              class: `icon-button ${item.getClasses?.(isFetching) || ""}`,
-              title: item.name,
-            };
-            return "url" in item ? (
-              <a href={item.url} {...props}>
-                {item.icon}
-              </a>
-            ) : (
-              <button onClick={item.onClick} {...props}>
-                {item.icon}
-              </button>
-            );
-          })}
+          <button
+            class={`icon-button ${isFetching ? "spin" : ""}`}
+            title="Refresh"
+            onClick={() => void queryClient.refetchQueries()}
+          >
+            <RefreshCw />
+          </button>
         </span>
       </div>
     </div>

--- a/src/components/navDrawer.css
+++ b/src/components/navDrawer.css
@@ -1,0 +1,71 @@
+/* The hamburger trigger is pinned to the top-right corner of the viewport so it
+   sits in the same place on every page (dashboard, goal, docs), floating just to
+   the right of the dashboard's filter + refresh row. */
+.navDrawer__trigger {
+  position: fixed;
+  top: var(--padding);
+  right: var(--padding);
+  z-index: 20;
+  color: var(--text);
+}
+
+/* Dim + capture clicks behind the panel; clicking it closes the drawer. */
+.navDrawer__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.navDrawer__panel {
+  width: min(20rem, 85vw);
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.4);
+  padding: var(--padding);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.navDrawer__close {
+  align-self: flex-end;
+  color: var(--text);
+  margin-bottom: var(--padding);
+}
+
+/* Groups are separated by a hairline rule rather than headings — the labels
+   carry the meaning, the rule just clusters related actions. */
+.navDrawer__group {
+  display: flex;
+  flex-direction: column;
+}
+
+.navDrawer__group + .navDrawer__group {
+  border-top: 1px solid rgba(128, 128, 128, 0.3);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.navDrawer__row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.5rem;
+  border: none;
+  background: none;
+  color: inherit;
+  text-decoration: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.navDrawer__row:hover {
+  background: rgba(128, 128, 128, 0.15);
+}

--- a/src/components/navDrawer.spec.tsx
+++ b/src/components/navDrawer.spec.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/preact";
+
+// ViewLink needs a router context (useNavigate); stub it to a plain anchor that
+// still forwards onClick so we can assert the drawer closes after navigation.
+vi.mock("./viewLink", () => ({
+  default: ({ children, onClick }: { children: unknown; onClick?: () => void }) => (
+    <a onClick={onClick}>{children as never}</a>
+  ),
+}));
+
+const { logoutSpy } = vi.hoisted(() => ({ logoutSpy: vi.fn() }));
+vi.mock("../auth", () => ({ logout: logoutSpy }));
+
+import NavDrawer from "./navDrawer";
+
+describe("NavDrawer", () => {
+  beforeEach(() => logoutSpy.mockReset());
+  // Renders mount into document.body; without this each test's drawer would
+  // accumulate and the scoped queries would match multiple triggers.
+  afterEach(cleanup);
+
+  it("hides the panel until the trigger is clicked", () => {
+    const { queryByText, getByLabelText } = render(<NavDrawer />);
+    expect(queryByText("Add goal")).toBeNull();
+
+    fireEvent.click(getByLabelText("Menu"));
+    expect(queryByText("Add goal")).not.toBeNull();
+    expect(queryByText("How bm works")).not.toBeNull();
+    expect(queryByText("Log out")).not.toBeNull();
+  });
+
+  it("closes when the close button is clicked", () => {
+    const { queryByText, getByLabelText } = render(<NavDrawer />);
+    fireEvent.click(getByLabelText("Menu"));
+    fireEvent.click(getByLabelText("Close menu"));
+    expect(queryByText("Add goal")).toBeNull();
+  });
+
+  it("closes on Escape", () => {
+    const { queryByText, getByLabelText } = render(<NavDrawer />);
+    fireEvent.click(getByLabelText("Menu"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByText("Add goal")).toBeNull();
+  });
+
+  it("closes when the overlay is clicked", () => {
+    const { container, queryByText, getByLabelText } = render(<NavDrawer />);
+    fireEvent.click(getByLabelText("Menu"));
+    fireEvent.click(container.querySelector(".navDrawer__overlay") as HTMLElement);
+    expect(queryByText("Add goal")).toBeNull();
+  });
+
+  it("runs an action and closes when its row is activated", () => {
+    const { queryByText, getByText, getByLabelText } = render(<NavDrawer />);
+    fireEvent.click(getByLabelText("Menu"));
+    fireEvent.click(getByText("Log out"));
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+    expect(queryByText("Add goal")).toBeNull();
+  });
+});

--- a/src/components/navDrawer.tsx
+++ b/src/components/navDrawer.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from "preact/hooks";
+import { JSX } from "preact/jsx-runtime";
+import {
+  BookOpen,
+  CirclePlus,
+  Gem,
+  LifeBuoy,
+  LogOut,
+  Menu,
+  Newspaper,
+  Settings,
+  TreePalm,
+  X,
+} from "lucide-preact";
+import { logout } from "../auth";
+import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
+import ViewLink from "./viewLink";
+import "./navDrawer.css";
+
+// The global navigation drawer: a hamburger pinned to the top-right of every
+// authenticated page that slides out a panel of the rarely-used actions. These
+// used to be a row of unlabelled icons crammed into the dashboard header; most
+// just deep-link out to Beeminder, so they live here behind labels instead,
+// leaving the header for the frequent controls (filter + refresh).
+
+type BaseItem = { name: string; icon: JSX.Element };
+// Opens an external site in this tab/new tab via a real anchor.
+type ExternalItem = BaseItem & { href: string };
+// Runs an in-app action (usually a Beeminder deep-link or logout).
+type ButtonItem = BaseItem & { onClick: () => void };
+// Navigates client-side to one of our own routes.
+type RouteItem = BaseItem & { to: string };
+type DrawerItem = ExternalItem | ButtonItem | RouteItem;
+
+// Beeminder actions that bounce out to beeminder.com (authenticated deep-links).
+const beeminderActions: DrawerItem[] = [
+  {
+    name: "Add goal",
+    icon: <CirclePlus />,
+    onClick: () => {
+      window.location.href = beeminderAuthUrl("https://beeminder.com/new");
+    },
+  },
+  {
+    name: "Add breaks",
+    icon: <TreePalm />,
+    onClick: () => {
+      const start = window.prompt("Start date (YYYY-MM-DD)") || "";
+      const finish = window.prompt("Finish date (YYYY-MM-DD)") || "";
+      const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+      if (!datePattern.test(start) || !datePattern.test(finish)) {
+        window.alert("Invalid date format. Please use YYYY-MM-DD.");
+        return;
+      }
+      const url = beeminderAuthUrl(
+        `https://beeminder.com/breaks?start=${start}&finish=${finish}`
+      );
+      window.open(url, "_blank", "noopener,noreferrer");
+    },
+  },
+  {
+    name: "Account settings",
+    icon: <Settings />,
+    onClick: () => {
+      window.location.href = beeminderAuthUrl(
+        "https://beeminder.com/settings/account"
+      );
+    },
+  },
+  {
+    name: "Premium",
+    icon: <Gem />,
+    onClick: () => {
+      window.location.href = beeminderAuthUrl(
+        "https://www.beeminder.com/premium"
+      );
+    },
+  },
+];
+
+// bm's own pages.
+const bmLinks: DrawerItem[] = [
+  { name: "How bm works", icon: <BookOpen />, to: "/docs" },
+];
+
+// Beeminder's own help/reference sites.
+const beeminderLinks: DrawerItem[] = [
+  { name: "Beeminder blog", icon: <Newspaper />, href: "https://blog.beeminder.com/" },
+  { name: "Beeminder help", icon: <LifeBuoy />, href: "https://help.beeminder.com/" },
+];
+
+const sessionActions: DrawerItem[] = [
+  { name: "Log out", icon: <LogOut />, onClick: logout },
+];
+
+// A single drawer row. Every variant closes the drawer when activated, so the
+// panel never lingers open over the page the user just navigated to.
+function DrawerRow({ item, close }: { item: DrawerItem; close: () => void }) {
+  if ("to" in item) {
+    return (
+      <ViewLink to={item.to} class="navDrawer__row" onClick={close}>
+        {item.icon}
+        <span>{item.name}</span>
+      </ViewLink>
+    );
+  }
+  if ("href" in item) {
+    return (
+      <a
+        class="navDrawer__row"
+        href={item.href}
+        target="_blank"
+        rel="noreferrer"
+        onClick={close}
+      >
+        {item.icon}
+        <span>{item.name}</span>
+      </a>
+    );
+  }
+  return (
+    <button
+      class="navDrawer__row"
+      onClick={() => {
+        item.onClick();
+        close();
+      }}
+    >
+      {item.icon}
+      <span>{item.name}</span>
+    </button>
+  );
+}
+
+const groups: DrawerItem[][] = [
+  beeminderActions,
+  bmLinks,
+  beeminderLinks,
+  sessionActions,
+];
+
+export default function NavDrawer() {
+  const [open, setOpen] = useState(false);
+  const close = () => setOpen(false);
+
+  // Escape closes the drawer, mirroring the goal pager's keyboard handling.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <>
+      <button
+        class="icon-button navDrawer__trigger"
+        title="Menu"
+        aria-label="Menu"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        <Menu />
+      </button>
+
+      {open && (
+        <div class="navDrawer__overlay" onClick={close}>
+          <nav
+            class="navDrawer__panel"
+            aria-label="Navigation"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              class="icon-button navDrawer__close"
+              title="Close menu"
+              aria-label="Close menu"
+              onClick={close}
+            >
+              <X />
+            </button>
+            {groups.map((group, i) => (
+              <div key={i} class="navDrawer__group">
+                {group.map((item) => (
+                  <DrawerRow key={item.name} item={item} close={close} />
+                ))}
+              </div>
+            ))}
+          </nav>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/navDrawer.tsx
+++ b/src/components/navDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-preact";
 import { logout } from "../auth";
 import { beeminderAuthUrl } from "../lib/beeminderAuthUrl";
+import breakDatesUrl from "../lib/breakDatesUrl";
 import ViewLink from "./viewLink";
 import "./navDrawer.css";
 
@@ -47,15 +48,12 @@ const beeminderActions: DrawerItem[] = [
     onClick: () => {
       const start = window.prompt("Start date (YYYY-MM-DD)") || "";
       const finish = window.prompt("Finish date (YYYY-MM-DD)") || "";
-      const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-      if (!datePattern.test(start) || !datePattern.test(finish)) {
+      const url = breakDatesUrl(start, finish);
+      if (!url) {
         window.alert("Invalid date format. Please use YYYY-MM-DD.");
         return;
       }
-      const url = beeminderAuthUrl(
-        `https://beeminder.com/breaks?start=${start}&finish=${finish}`
-      );
-      window.open(url, "_blank", "noopener,noreferrer");
+      window.open(beeminderAuthUrl(url), "_blank", "noopener,noreferrer");
     },
   },
   {

--- a/src/lib/breakDatesUrl.spec.ts
+++ b/src/lib/breakDatesUrl.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import breakDatesUrl from "./breakDatesUrl";
+
+describe("breakDatesUrl", () => {
+  it("builds the breaks URL for two valid dates", () => {
+    expect(breakDatesUrl("2026-06-13", "2026-06-20")).toBe(
+      "https://beeminder.com/breaks?start=2026-06-13&finish=2026-06-20"
+    );
+  });
+
+  it("returns null when the start date is malformed", () => {
+    expect(breakDatesUrl("6/13/2026", "2026-06-20")).toBeNull();
+  });
+
+  it("returns null when the finish date is malformed", () => {
+    expect(breakDatesUrl("2026-06-13", "")).toBeNull();
+  });
+
+  it("returns null when both dates are empty (cancelled prompts)", () => {
+    expect(breakDatesUrl("", "")).toBeNull();
+  });
+});

--- a/src/lib/breakDatesUrl.ts
+++ b/src/lib/breakDatesUrl.ts
@@ -1,0 +1,16 @@
+// The "Add breaks" action asks for a start and finish date and sends the user
+// to Beeminder's breaks page for that range. This is the pure, testable core:
+// validate the two dates and build the (un-authenticated) breaks URL, or return
+// null if either date isn't `YYYY-MM-DD`. The prompts, the auth-wrapping, and
+// the window it opens stay in the caller — only this validation/encoding lives
+// here, matching the buildHref/goalKeyAction "logic in lib, side effects in the
+// component" split.
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export default function breakDatesUrl(
+  start: string,
+  finish: string
+): string | null {
+  if (!DATE_PATTERN.test(start) || !DATE_PATTERN.test(finish)) return null;
+  return `https://beeminder.com/breaks?start=${start}&finish=${finish}`;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import { Router, RootRoute, Route } from "@tanstack/react-router";
 import { App } from "./components/app";
 import Dashboard from "./components/dashboard";
 import GoalPage from "./components/goalPage";
+import DocsPage from "./components/docsPage";
 
 // The app layout (auth gate, dark shell, footer) lives at the root and renders
 // an <Outlet/> for whichever page is active.
@@ -22,7 +23,14 @@ const goalRoute = new Route({
   component: GoalPage,
 });
 
-const routeTree = rootRoute.addChildren([indexRoute, goalRoute]);
+// The in-app user guide / fineprint-tag reference.
+const docsRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: "docs",
+  component: DocsPage,
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, goalRoute, docsRoute]);
 
 export const router = new Router({ routeTree });
 


### PR DESCRIPTION
## What

Reworks the nav architecture and adds an in-app docs page.

### Nav drawer
- Moves the rarely-used dashboard-header actions (Add goal, Add breaks, Account settings, Premium, Beeminder blog/help, Log out) into a **global slide-out drawer** behind a ☰ trigger pinned to the top-right of every page (mounted in the app shell, so it's available on the dashboard, goal pages, and docs page alike).
- Slims the dashboard header down to the two frequent, dashboard-specific controls: the **filter** box and **Refresh**.
- Drawer closes on overlay click, `Escape`, or activating any item.

### Docs page (`/docs`)
- New "How bm works" guide covering what bm is, the four goal groups, keyboard navigation, and — the centerpiece — the **`#bm` fineprint tags** (`#bmPin`, `#bmAutodata=<url>`, Do Less auto-pin).
- Reachable from the drawer and the footer.
- Wording verified against the real implementation (`getGroup.ts`, `goalKeyAction.ts`, `directives.ts`, `useGoalMutations.ts`): pinning is by goal type + tag (not buffer), and `#bmAutodata` is *fetched* to trigger a sync (not opened).

### Refactor
- Extracts the "Add breaks" date validation/URL building into a pure `lib/breakDatesUrl.ts` helper with tests, matching the repo's `buildHref`/`goalKeyAction` convention.

## Testing
- `pnpm checkTs`, `pnpm lint`, and `pnpm exec vitest run` (135 tests) all pass.
- New specs: `navDrawer.spec.tsx`, `docsPage.spec.tsx`, `breakDatesUrl.spec.ts`.

## Notes
- Pre-existing (not addressed here): the authenticated Beeminder deep-links use `window.location.href`, which can leak the API token via the `Referer` header on redirect. This code was moved verbatim from the old header; worth a separate issue if we want to harden it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)