### PR TITLE
style: full-bleed, square-cornered goal detail header

### DIFF
--- a/src/components/goalPage.css
+++ b/src/components/goalPage.css
@@ -1,16 +1,11 @@
-/* The single-goal page: a centred, readable column rather than the modal's
-   fixed 500px box. On wide screens it grows into a two-column layout (see
+/* The single-goal page mirrors the grid: the goal sits on a full-bleed,
+   square-cornered surface that runs edge to edge, rather than the modal's
+   fixed 500px box. The top "back" control keeps a small side gutter like the
+   dashboard header, and extra top room separates it from the nav drawer's
+   fixed trigger. On wide screens the body splits into two columns (see
    detail.css) so the graph and data sit side by side instead of stacking. */
 .goalPage {
-  max-width: 540px;
-  margin: 0 auto;
-  padding: var(--padding);
-}
-
-@media (min-width: 900px) {
-  .goalPage {
-    max-width: 1080px;
-  }
+  padding-top: 1rem;
 }
 
 .goalPage__back {
@@ -18,11 +13,10 @@
   align-items: center;
   gap: 0.25rem;
   margin-bottom: var(--padding);
+  padding: 0 var(--padding);
   font-size: 0.9rem;
 }
 
 .goalPage .detail {
   background-color: var(--bg);
-  border-radius: 5px;
-  overflow: hidden;
 }


### PR DESCRIPTION
## What

Now that goal detail is its own page, make it look cohesive with the grid page.

- **Removed the rounded corners** from the detail surface (`border-radius` + `overflow: hidden`), so the colored status header has square corners like the grid's goal cards.
- **Full-bleed left and right** — dropped the centred `max-width` (540/1080px) and the horizontal page padding, so the detail surface runs edge to edge. The "← Dashboard" back control keeps a small side gutter, matching the dashboard header.
- **More top room** — bumped the page's top padding from `0.5rem` to `1rem` to separate the content from the nav drawer's fixed trigger.

Single file touched: `src/components/goalPage.css`.

## Trade-off

Dropping `max-width` means on very wide monitors the two-column detail body now stretches the full viewport width (longer line lengths) rather than capping at 1080px. That's the literal consequence of full-bleed, and it matches how the grid already behaves.

## Verification

Drove the real components + CSS in a browser (credentials injected, goals API mocked) at narrow and wide widths. Confirmed via computed styles: detail surface `left: 0` / `right: viewportWidth` (full bleed), `border-radius: 0px`, page `padding-top: 16px`. Two-column body intact on wide screens. Test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned goal page layout to extend edge-to-edge across the entire screen
  * Adjusted spacing on navigation controls to maintain consistent alignment
  * Refined detail sections with a modern appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->