### PR TITLE
feat: clocky format for limsum bar and datapoints table

### DIFF
--- a/src/components/datapointRow.tsx
+++ b/src/components/datapointRow.tsx
@@ -2,12 +2,15 @@ import useGoalMutations from "../useGoalMutations";
 import cnx from "../cnx";
 import "./datapointRow.css";
 import { Copy, Trash } from "lucide-preact";
+import { formatClocky } from "../lib/clocky";
 
 export default function DatapointRow({
   goal,
+  hhmmformat,
   point,
 }: {
   goal: string;
+  hhmmformat?: boolean;
   point: {
     id: string;
     daystamp: string;
@@ -21,7 +24,7 @@ export default function DatapointRow({
     <tr key={point.id} data-id={point.id} class="datapoint-row">
       <td>{point.daystamp}</td>
       <td>{point.comment}</td>
-      <td>{point.value}</td>
+      <td>{hhmmformat ? formatClocky(point.value) : point.value}</td>
       <td>
         <button
           type="button"

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -8,6 +8,7 @@ import DOMPurify from "isomorphic-dompurify";
 import { marked } from "marked";
 import convertDeadlineToTime from "../services/beeminder/convertDeadlineToTime";
 import sigfigs from "../lib/sigfigs";
+import { clockifyLimsum } from "../lib/clocky";
 import { ArrowLeft, ArrowRight } from "lucide-preact";
 import { ComponentChildren } from "preact";
 import { isPlainLeftClick } from "../lib/viewTransition";
@@ -93,7 +94,7 @@ export default function Detail({
         <PagerArrow href={prevHref} onActivate={goPrev} label="Previous goal">
           <ArrowLeft />
         </PagerArrow>
-        <span>{g.limsumdate}</span>
+        <span>{g.hhmmformat ? clockifyLimsum(g.limsumdate) : g.limsumdate}</span>
         <span>
           {position} of {count}
         </span>
@@ -153,6 +154,7 @@ export default function Detail({
                 <DatapointRow
                   key={point.id}
                   goal={g.slug}
+                  hhmmformat={g.hhmmformat}
                   point={{
                     id: point.id,
                     daystamp: point.daystamp,

--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -15,6 +15,11 @@ describe("formatClocky", () => {
   it("rounds to the nearest minute", () => {
     expect(formatClocky(0.119)).toBe("0:07");
   });
+
+  it("does not emit a signed zero for tiny negatives", () => {
+    expect(formatClocky(-0.001)).toBe("0:00");
+    expect(formatClocky(0)).toBe("0:00");
+  });
 });
 
 describe("clockifyLimsum", () => {
@@ -30,5 +35,13 @@ describe("clockifyLimsum", () => {
 
   it("handles an unsigned leading value", () => {
     expect(clockifyLimsum("1.5 due Sat")).toBe("1:30 due Sat");
+  });
+
+  it("handles an integer leading value", () => {
+    expect(clockifyLimsum("+5 due Sat")).toBe("+5:00 due Sat");
+  });
+
+  it("leaves strings with no leading value untouched", () => {
+    expect(clockifyLimsum("due Sat")).toBe("due Sat");
   });
 });

--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { formatClocky, clockifyLimsum } from "./clocky";
+
+describe("formatClocky", () => {
+  it("formats decimal hours as H:MM", () => {
+    expect(formatClocky(1.5)).toBe("1:30");
+    expect(formatClocky(0.08289)).toBe("0:05");
+    expect(formatClocky(2)).toBe("2:00");
+  });
+
+  it("preserves the sign of negative values", () => {
+    expect(formatClocky(-2.5)).toBe("-2:30");
+  });
+
+  it("rounds to the nearest minute", () => {
+    expect(formatClocky(0.119)).toBe("0:07");
+  });
+});
+
+describe("clockifyLimsum", () => {
+  it("rewrites the leading value, keeping the rest", () => {
+    expect(clockifyLimsum("+0.08289 due Sat by 09:00")).toBe(
+      "+0:05 due Sat by 09:00"
+    );
+  });
+
+  it("preserves a negative sign", () => {
+    expect(clockifyLimsum("-2.5 within 1 day")).toBe("-2:30 within 1 day");
+  });
+
+  it("handles an unsigned leading value", () => {
+    expect(clockifyLimsum("1.5 due Sat")).toBe("1:30 due Sat");
+  });
+});

--- a/src/lib/clocky.ts
+++ b/src/lib/clocky.ts
@@ -3,8 +3,8 @@
 
 // Decimal hours → "H:MM", preserving sign and zero-padding minutes.
 export function formatClocky(hours: number): string {
-  const sign = hours < 0 ? "-" : "";
   const totalMinutes = Math.round(Math.abs(hours) * 60);
+  const sign = hours < 0 && totalMinutes > 0 ? "-" : "";
   const h = Math.floor(totalMinutes / 60);
   const m = totalMinutes % 60;
   return `${sign}${h}:${m.toString().padStart(2, "0")}`;
@@ -15,6 +15,6 @@ export function formatClocky(hours: number): string {
 export function clockifyLimsum(limsum: string): string {
   return limsum.replace(/^[+-]?\d+(\.\d+)?/, (m) => {
     const s = formatClocky(Number(m));
-    return m.startsWith("+") && !s.startsWith("-") ? `+${s}` : s;
+    return m.startsWith("+") ? `+${s}` : s;
   });
 }

--- a/src/lib/clocky.ts
+++ b/src/lib/clocky.ts
@@ -1,0 +1,20 @@
+// Formatting for "clocky" goals (Beeminder's hhmmformat), whose values are
+// decimal hours that read better as clock time: 0.08289 → "0:05", 1.5 → "1:30".
+
+// Decimal hours → "H:MM", preserving sign and zero-padding minutes.
+export function formatClocky(hours: number): string {
+  const sign = hours < 0 ? "-" : "";
+  const totalMinutes = Math.round(Math.abs(hours) * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${sign}${h}:${m.toString().padStart(2, "0")}`;
+}
+
+// Rewrite the leading numeric value of a limsum/limsumdate string in clocky form,
+// leaving the rest ("due Sat by 09:00") untouched. Keeps an explicit leading "+".
+export function clockifyLimsum(limsum: string): string {
+  return limsum.replace(/^[+-]?\d+(\.\d+)?/, (m) => {
+    const s = formatClocky(Number(m));
+    return m.startsWith("+") && !s.startsWith("-") ? `+${s}` : s;
+  });
+}


### PR DESCRIPTION
Closes #45

## Problem

For clocky goals (Beeminder's `hhmmformat`), the goal-detail **limsum bar** and **recent datapoints table** showed raw decimal hours while the goal grid already used clock format:

- limsum bar: `+0.08289 due Sat by 09:00`
- datapoints value column: `0.08777777777777777`

## Change

New pure helper `src/lib/clocky.ts`:
- `formatClocky(hours)` → `"H:MM"` (sign-aware, minute-rounded)
- `clockifyLimsum(str)` → rewrites only the leading numeric value of a limsum string, leaving `due Sat by 09:00` untouched

Wired into `detail.tsx` (limsum bar) and `datapointRow.tsx` (value column), gated on `g.hhmmformat`. Non-clocky goals are unchanged.

Now clocky goals show `+0:05 due Sat by 09:00` and `0:05` respectively.

## Tests

`src/lib/clocky.spec.ts` covers positive/negative/integer/zero formatting, minute rounding, the `-0:00` edge case, and limsum rewriting (signed, unsigned, integer, no-match). Full suite: 144 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional clock-style formatting for datapoint values and goal summaries when time-format display is enabled.
  * Numeric time values are now shown in a cleaner `H:MM` format, including proper handling of negatives and rounding.

* **Bug Fixes**
  * Preserves the rest of summary text while formatting only the leading time value.
  * Avoids awkward `-0:00` output for tiny negative values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->