### PR TITLE
fix: scroll hamburger trigger with the page instead of pinning it

### DIFF
--- a/src/components/app.css
+++ b/src/components/app.css
@@ -51,7 +51,12 @@ body {
   color: inherit;
 }
 
-.app__content {
+/* The one scroll region: the page (via the <Outlet/>) and the nav drawer's
+   hamburger trigger live in here and scroll together, so the trigger rides up
+   with the page instead of staying pinned. The footer sits outside, below it.
+   position: relative anchors the trigger's absolute positioning. */
+.app__scroll {
+  position: relative;
   flex-grow: 1;
   overflow-y: scroll;
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -15,8 +15,10 @@ function Layout() {
 
   return (
     <div class={`app__base app__dark`}>
-      <NavDrawer />
-      <Outlet />
+      <div class="app__scroll">
+        <NavDrawer />
+        <Outlet />
+      </div>
       <Footer />
     </div>
   );

--- a/src/components/goalPage.css
+++ b/src/components/goalPage.css
@@ -2,7 +2,7 @@
    square-cornered surface that runs edge to edge, rather than the modal's
    fixed 500px box. The top "back" control keeps a small side gutter like the
    dashboard header, and extra top room separates it from the nav drawer's
-   fixed trigger. On wide screens the body splits into two columns (see
+   trigger. On wide screens the body splits into two columns (see
    detail.css) so the graph and data sit side by side instead of stacking. */
 .goalPage {
   padding-top: 1rem;

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -3,8 +3,8 @@
     --input-text-color: white;
 }
 
-/* Leave room on the right for the NavDrawer's fixed hamburger trigger so the
-   refresh button doesn't sit underneath it. */
+/* Leave room on the right for the NavDrawer's hamburger trigger so the refresh
+   button doesn't sit underneath it. */
 .main-header .global-controls {
     padding-right: 2.25rem;
 }

--- a/src/components/navDrawer.css
+++ b/src/components/navDrawer.css
@@ -1,8 +1,9 @@
-/* The hamburger trigger is pinned to the top-right corner of the viewport so it
-   sits in the same place on every page (dashboard, goal, docs), floating just to
-   the right of the dashboard's filter + refresh row. */
+/* The hamburger trigger sits at the top-right of the scroll region (.app__scroll)
+   rather than the viewport, so it scrolls up with the page content instead of
+   staying fixed in the corner. At rest it floats just right of the dashboard's
+   filter + refresh row. */
 .navDrawer__trigger {
-  position: fixed;
+  position: absolute;
   top: var(--padding);
   right: var(--padding);
   z-index: 20;


### PR DESCRIPTION
## Problem

The nav drawer's hamburger stayed fixed in the top-right corner of the viewport while the page scrolled underneath it — so on the goal page it floated over content instead of riding up with the back-to-dashboard link.

## Fix

The hamburger lived in the app shell *outside* the per-page scroll container (`.app__content`), so CSS alone couldn't make it scroll with content. This wraps the trigger and the page `<Outlet/>` in a single shell-level scroll region (`.app__scroll`) and switches the trigger from `position: fixed` to `position: absolute` within it. The trigger now scrolls up with page content; the drawer overlay/panel stay `fixed`.

Scrolling moved from the per-page `.app__content` wrappers up to `.app__scroll`, so the old `.app__content` scroll rule is removed (the wrapper divs remain as plain containers). The footer still pins below the scroll region.

### Note
A side effect: on the dashboard, the filter + refresh header now scrolls with the page too (it was previously fixed at the top). This is consistent with the requested behavior — everything in the page scrolls together with the hamburger — but flagging it in case the filter row should instead stay sticky.

## Testing
- `tsc --noEmit` clean
- 144 tests pass
- Local review loop (CLAUDE.md / bug / git-history / comments / CSS-regression agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the page layout so the main content and navigation trigger scroll together.
  * The hamburger trigger now moves with the page instead of staying fixed on screen.
  * Kept the footer outside the scrolling area for a more consistent layout.

* **Style**
  * Minor comment and whitespace updates in component styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->