### PR TITLE
feat: open goal title in new tab on cmd/ctrl-click

### DIFF
--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -83,6 +83,14 @@ export default function Detail({
   // auth token stays inside beeminderAuthUrl.
   const { username } = getCredentials();
 
+  // The beeminder.com goal page. The visible href is token-free; every actual
+  // navigation goes through beeminderAuthUrl so the deep-link stays authed —
+  // including new-tab opens from modifier-clicks (click) and middle-clicks
+  // (auxclick), which the browser would otherwise send to the raw href.
+  const goalUrl = `https://beeminder.com/${username}/${g.slug}`;
+  const openGoalInNewTab = () =>
+    window.open(beeminderAuthUrl(goalUrl), "_blank", "noopener,noreferrer");
+
   return (
     <div
       class="detail"
@@ -106,17 +114,22 @@ export default function Detail({
       <div class="detail__header">
         <div>
           <a
-            href={`https://beeminder.com/${username}/${g.slug}`}
+            href={goalUrl}
             onClick={(e) => {
               e.preventDefault();
-              const url = beeminderAuthUrl(
-                `https://beeminder.com/${username}/${g.slug}`
-              );
               if (isPlainLeftClick(e)) {
-                window.location.href = url;
+                window.location.href = beeminderAuthUrl(goalUrl);
               } else {
-                window.open(url, "_blank", "noopener,noreferrer");
+                openGoalInNewTab();
               }
+            }}
+            // click doesn't fire for the middle button; auxclick does. Intercept
+            // button 1 so middle-click also opens the authed URL (leave other
+            // buttons, e.g. right-click for the context menu, to the browser).
+            onAuxClick={(e) => {
+              if (e.button !== 1) return;
+              e.preventDefault();
+              openGoalInNewTab();
             }}
             class="detail__headerText"
           >

--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -109,9 +109,14 @@ export default function Detail({
             href={`https://beeminder.com/${username}/${g.slug}`}
             onClick={(e) => {
               e.preventDefault();
-              window.location.href = beeminderAuthUrl(
+              const url = beeminderAuthUrl(
                 `https://beeminder.com/${username}/${g.slug}`
               );
+              if (isPlainLeftClick(e)) {
+                window.location.href = url;
+              } else {
+                window.open(url, "_blank", "noopener,noreferrer");
+              }
             }}
             class="detail__headerText"
           >


### PR DESCRIPTION
Closes #48.

Command/ctrl-clicking the goal title on the detail page previously opened beeminder.com in the **same** tab — the `onClick` handler always called `preventDefault()` and set `window.location.href`, swallowing modifier-click intent.

Now the handler reuses the existing `isPlainLeftClick` helper: a plain left click navigates in the same tab (as before), while any modified click (cmd/ctrl/shift/alt) opens the goal in a new tab via `window.open`. Both paths keep the authenticated `beeminderAuthUrl` deep-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal link behavior so normal left-clicks navigate in the current tab, while other click types open the destination in a new tab.
  * Added safer new-tab handling to reduce the risk of exposing the current page context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->