### PR TITLE
fix(clocky): round amount due up to the next minute

### DIFF
--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -41,6 +41,11 @@ describe("clockifyLimsum", () => {
     expect(clockifyLimsum("+5 due Sat")).toBe("+5:00 due Sat");
   });
 
+  it("rounds the amount due up to the next minute", () => {
+    // 00:05:01 required (0.083611 h) must not read as 0:05
+    expect(clockifyLimsum("+0.083611 due Sat")).toBe("+0:06 due Sat");
+  });
+
   it("leaves strings with no leading value untouched", () => {
     expect(clockifyLimsum("due Sat")).toBe("due Sat");
   });

--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -46,6 +46,10 @@ describe("clockifyLimsum", () => {
     expect(clockifyLimsum("+0.083611 due Sat")).toBe("+0:06 due Sat");
   });
 
+  it("rounds up by magnitude for negative fractional values", () => {
+    expect(clockifyLimsum("-0.083611 due Sat")).toBe("-0:06 due Sat");
+  });
+
   it("leaves strings with no leading value untouched", () => {
     expect(clockifyLimsum("due Sat")).toBe("due Sat");
   });

--- a/src/lib/clocky.ts
+++ b/src/lib/clocky.ts
@@ -2,8 +2,11 @@
 // decimal hours that read better as clock time: 0.08289 → "0:05", 1.5 → "1:30".
 
 // Decimal hours → "H:MM", preserving sign and zero-padding minutes.
-export function formatClocky(hours: number): string {
-  const totalMinutes = Math.round(Math.abs(hours) * 60);
+// roundUp rounds partial minutes up, so an amount due never reads as less than
+// what's actually required (00:05:01 → "0:06", not "0:05").
+export function formatClocky(hours: number, roundUp = false): string {
+  const round = roundUp ? Math.ceil : Math.round;
+  const totalMinutes = round(Math.abs(hours) * 60);
   const sign = hours < 0 && totalMinutes > 0 ? "-" : "";
   const h = Math.floor(totalMinutes / 60);
   const m = totalMinutes % 60;
@@ -14,7 +17,7 @@ export function formatClocky(hours: number): string {
 // leaving the rest ("due Sat by 09:00") untouched. Keeps an explicit leading "+".
 export function clockifyLimsum(limsum: string): string {
   return limsum.replace(/^[+-]?\d+(\.\d+)?/, (m) => {
-    const s = formatClocky(Number(m));
+    const s = formatClocky(Number(m), true);
     return m.startsWith("+") ? `+${s}` : s;
   });
 }


### PR DESCRIPTION
Whenever the dashboard shows a clocky goal's amount due (the limsum), partial minutes now round **up** so the displayed time is never less than what's actually required — e.g. 00:05:01 to satisfy a goal shows `0:06`, not `0:05`.

- `formatClocky` gains an opt-in `roundUp` flag (default off).
- `clockifyLimsum` (the amount-due path in `detail.tsx`) passes it.
- Historical datapoint values (`datapointRow.tsx`) keep nearest-minute rounding.

Existing behavior preserved: `0.08289 h` (4.97 min) still shows `0:05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time formatting so partial minutes now round up when calculating due amounts, preventing underreported time.
  * Preserved the original “due …” text suffix while updating the leading time value.
  * Added test coverage for fractional values just above a five-minute boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->