### PR TITLE
fix(grid): round clocky amount due up to match goal detail

### DIFF
--- a/src/components/countdown.tsx
+++ b/src/components/countdown.tsx
@@ -65,7 +65,7 @@ export default function Countdown({ g }: { g: Goal }) {
 
   return (
     <W>
-      {getPrefix(g.baremin)} {Math.floor(+seconds / Unit[u])}
+      {getPrefix(g)} {Math.floor(+seconds / Unit[u])}
       {u}
     </W>
   );

--- a/src/lib/countdown.spec.ts
+++ b/src/lib/countdown.spec.ts
@@ -58,6 +58,11 @@ describe("getPrefix", () => {
     ).toBe("-1:15 in");
   });
 
+  it("formats an exact-minute clocky amount without a ceil bump", () => {
+    expect(getPrefix(goal({ limsum: "1 in 0 days", hhmmformat: true }))).toBe("1:00 in");
+    expect(getPrefix(goal({ limsum: "0.5 in 0 days", hhmmformat: true }))).toBe("0:30 in");
+  });
+
   it("degrades to a bare ' in' when there's no amount", () => {
     expect(getPrefix(goal({}))).toBe(" in");
     expect(getPrefix(goal({ hhmmformat: true }))).toBe(" in");

--- a/src/lib/countdown.spec.ts
+++ b/src/lib/countdown.spec.ts
@@ -30,21 +30,36 @@ describe("secondsUntil", () => {
 });
 
 describe("getPrefix", () => {
-  it("formats a bare number", () => {
-    expect(getPrefix("1")).toBe("1 in");
-    expect(getPrefix("1.5")).toBe("1.5 in");
-  });
+  const goal = (o: { baremin?: string; limsum?: string; hhmmformat?: boolean }) =>
+    ({ baremin: "", limsum: "", hhmmformat: false, ...o }) as Parameters<
+      typeof getPrefix
+    >[0];
 
-  it("prefers an h:mm time over a number", () => {
-    expect(getPrefix("2:30")).toBe("2:30 in");
+  it("formats a bare number for non-clocky goals", () => {
+    expect(getPrefix(goal({ baremin: "1" }))).toBe("1 in");
+    expect(getPrefix(goal({ baremin: "1.5" }))).toBe("1.5 in");
   });
 
   it("keeps a leading minus sign", () => {
-    expect(getPrefix("-3")).toBe("-3 in");
-    expect(getPrefix("-1:15")).toBe("-1:15 in");
+    expect(getPrefix(goal({ baremin: "-3" }))).toBe("-3 in");
   });
 
-  it("degrades to a bare ' in' for an empty baremin", () => {
-    expect(getPrefix("")).toBe(" in");
+  it("rounds a clocky goal's amount up to the next minute", () => {
+    // 0.0912h = 5.47min → ceils to 0:06, matching the goal detail page rather
+    // than Beeminder's nearest-minute baremin of "0:05".
+    expect(
+      getPrefix(goal({ baremin: "0:05", limsum: "0.0912 in 0 days", hhmmformat: true }))
+    ).toBe("0:06 in");
+  });
+
+  it("keeps a clocky minus sign", () => {
+    expect(
+      getPrefix(goal({ limsum: "-1.25 in 2 days", hhmmformat: true }))
+    ).toBe("-1:15 in");
+  });
+
+  it("degrades to a bare ' in' when there's no amount", () => {
+    expect(getPrefix(goal({}))).toBe(" in");
+    expect(getPrefix(goal({ hhmmformat: true }))).toBe(" in");
   });
 });

--- a/src/lib/countdown.ts
+++ b/src/lib/countdown.ts
@@ -1,4 +1,5 @@
 import { Goal } from "../services/beeminder";
+import { formatClocky } from "./clocky";
 
 // The math behind the goal countdown: how long until a goal derails, which time
 // unit to show that in, and the rate prefix parsed from Beeminder's `baremin`.
@@ -26,12 +27,20 @@ export function secondsUntil(losedate: number, now: Date = new Date()): number {
   return (losedate * 1000 - now.getTime()) / 1000;
 }
 
-// The rate prefix shown before the countdown, parsed from Beeminder's `baremin`
-// (e.g. "-2:30" → "-2:30 in", "1.5" → "1.5 in"). Keeps a leading minus sign and
-// prefers an "h:mm" time over a bare number.
-export function getPrefix(baremin: Goal["baremin"]): string {
-  const sign = baremin.includes("-") ? "-" : "";
-  const time = baremin.match(/[1-9]?\d:\d\d/)?.[0];
-  const number = baremin.match(/(\d+\.?\d?\d?)/)?.[1] || "";
-  return `${sign}${time || number} in`;
+// The rate prefix shown before the countdown. For clocky (hhmmformat) goals we
+// format the raw decimal amount from `limsum` ourselves, rounding partial
+// minutes up so the grid never reads less than the goal detail page — which
+// clockifies the same decimal — and stays pessimistic. Beeminder's own
+// `baremin` rounds to the nearest minute (0.0912h → "0:05", not "0:06"), so we
+// don't trust it for clocky goals. For other goals we show `baremin` directly.
+export function getPrefix(
+  g: Pick<Goal, "baremin" | "limsum" | "hhmmformat">
+): string {
+  if (g.hhmmformat) {
+    const amount = g.limsum.match(/^[+-]?\d+(\.\d+)?/)?.[0];
+    return `${amount ? formatClocky(Number(amount), true) : ""} in`;
+  }
+  const sign = g.baremin.includes("-") ? "-" : "";
+  const number = g.baremin.match(/(\d+\.?\d?\d?)/)?.[1] || "";
+  return `${sign}${number} in`;
 }


### PR DESCRIPTION
## Problem

For clocky (hhmmformat) goals, the grid and the goal detail page could disagree on the amount due — e.g. `ppd-finance` read `0:05` in the grid but `0:06` in the detail. The grid could show *less* than what's actually required, defeating pessimistic rounding.

## Cause

- The grid's `getPrefix` read Beeminder's pre-formatted `baremin`, which rounds to the **nearest** minute (`0.0912h` → `"0:05"`).
- The detail page clockifies the raw decimal in `limsum`/`limsumdate` with **round-up** (`0.0912h` = 5.47min → `"0:06"`).

## Fix

For clocky goals, the grid now formats the same raw `limsum` decimal with `formatClocky(_, roundUp=true)`, so both round partial minutes up and agree. Non-clocky goals still show `baremin` unchanged.

Tests updated to cover clocky round-up and sign handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved countdown prefix formatting for remaining time.
  * Countdown now handles clock-style goals more consistently, including minute rounding and minus-sign display.
  * Fixed cases where missing or incomplete goal values could produce awkward prefix text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->