### PR TITLE
fix(clocky): source amount due from baremin, not limsum

### DIFF
--- a/src/components/detail.tsx
+++ b/src/components/detail.tsx
@@ -102,7 +102,9 @@ export default function Detail({
         <PagerArrow href={prevHref} onActivate={goPrev} label="Previous goal">
           <ArrowLeft />
         </PagerArrow>
-        <span>{g.hhmmformat ? clockifyLimsum(g.limsumdate) : g.limsumdate}</span>
+        <span>
+          {g.hhmmformat ? clockifyLimsum(g.limsumdate, g.baremin) : g.limsumdate}
+        </span>
         <span>
           {position} of {count}
         </span>

--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatClocky, clockifyLimsum } from "./clocky";
+import { formatClocky, formatClockyClock, clockifyLimsum } from "./clocky";
 
 describe("formatClocky", () => {
   it("formats decimal hours as H:MM", () => {
@@ -22,35 +22,53 @@ describe("formatClocky", () => {
   });
 });
 
+describe("formatClockyClock", () => {
+  it("reformats a second-precise HH:MM:SS amount to H:MM", () => {
+    expect(formatClockyClock("+00:06:00")).toBe("0:06");
+    expect(formatClockyClock("+00:57:01")).toBe("0:58");
+    expect(formatClockyClock("+01:30:00")).toBe("1:30");
+  });
+
+  it("rounds any partial minute up", () => {
+    // 00:06:01 required must not read as 0:06
+    expect(formatClockyClock("+00:06:01")).toBe("0:07");
+    expect(formatClockyClock("+00:04:16")).toBe("0:05");
+  });
+
+  it("preserves a negative sign", () => {
+    expect(formatClockyClock("-00:06:00")).toBe("-0:06");
+  });
+
+  it("returns an empty string when there's no clock value", () => {
+    expect(formatClockyClock("")).toBe("");
+    expect(formatClockyClock("1.5")).toBe("");
+  });
+});
+
 describe("clockifyLimsum", () => {
-  it("rewrites the leading value, keeping the rest", () => {
-    expect(clockifyLimsum("+0.08289 due Sat by 09:00")).toBe(
-      "+0:05 due Sat by 09:00"
+  it("rewrites the leading value from baremin, keeping the rest", () => {
+    // limsum's own "+1" is unreliable; the amount comes from baremin.
+    expect(clockifyLimsum("+1 due Sat by 09:00", "+00:06:00")).toBe(
+      "+0:06 due Sat by 09:00"
     );
   });
 
   it("preserves a negative sign", () => {
-    expect(clockifyLimsum("-2.5 within 1 day")).toBe("-2:30 within 1 day");
+    expect(clockifyLimsum("-2.5 within 1 day", "-00:06:00")).toBe(
+      "-0:06 within 1 day"
+    );
   });
 
   it("handles an unsigned leading value", () => {
-    expect(clockifyLimsum("1.5 due Sat")).toBe("1:30 due Sat");
-  });
-
-  it("handles an integer leading value", () => {
-    expect(clockifyLimsum("+5 due Sat")).toBe("+5:00 due Sat");
+    expect(clockifyLimsum("1.5 due Sat", "+01:30:00")).toBe("1:30 due Sat");
   });
 
   it("rounds the amount due up to the next minute", () => {
-    // 00:05:01 required (0.083611 h) must not read as 0:05
-    expect(clockifyLimsum("+0.083611 due Sat")).toBe("+0:06 due Sat");
-  });
-
-  it("rounds up by magnitude for negative fractional values", () => {
-    expect(clockifyLimsum("-0.083611 due Sat")).toBe("-0:06 due Sat");
+    // 00:06:01 required must not read as 0:06
+    expect(clockifyLimsum("+1 due Sat", "+00:06:01")).toBe("+0:07 due Sat");
   });
 
   it("leaves strings with no leading value untouched", () => {
-    expect(clockifyLimsum("due Sat")).toBe("due Sat");
+    expect(clockifyLimsum("due Sat", "+00:06:00")).toBe("due Sat");
   });
 });

--- a/src/lib/clocky.spec.ts
+++ b/src/lib/clocky.spec.ts
@@ -39,6 +39,11 @@ describe("formatClockyClock", () => {
     expect(formatClockyClock("-00:06:00")).toBe("-0:06");
   });
 
+  it("never emits a signed zero", () => {
+    expect(formatClockyClock("-00:00:00")).toBe("0:00");
+    expect(formatClockyClock("+00:00:00")).toBe("0:00");
+  });
+
   it("returns an empty string when there's no clock value", () => {
     expect(formatClockyClock("")).toBe("");
     expect(formatClockyClock("1.5")).toBe("");

--- a/src/lib/clocky.ts
+++ b/src/lib/clocky.ts
@@ -33,5 +33,8 @@ export function formatClockyClock(clock: string): string {
 // untouched.
 export function clockifyLimsum(limsum: string, baremin: string): string {
   const amount = formatClockyClock(baremin).replace(/^[+-]/, "");
-  return limsum.replace(/^([+-]?)\d+(\.\d+)?/, (_m, sign) => `${sign}${amount}`);
+  return limsum.replace(
+    /^([+-]?)\d+(\.\d+)?/,
+    (_m, sign: string) => `${sign}${amount}`
+  );
 }

--- a/src/lib/clocky.ts
+++ b/src/lib/clocky.ts
@@ -1,23 +1,37 @@
 // Formatting for "clocky" goals (Beeminder's hhmmformat), whose values are
 // decimal hours that read better as clock time: 0.08289 → "0:05", 1.5 → "1:30".
 
-// Decimal hours → "H:MM", preserving sign and zero-padding minutes.
-// roundUp rounds partial minutes up, so an amount due never reads as less than
-// what's actually required (00:05:01 → "0:06", not "0:05").
-export function formatClocky(hours: number, roundUp = false): string {
-  const round = roundUp ? Math.ceil : Math.round;
-  const totalMinutes = round(Math.abs(hours) * 60);
+// Decimal hours → "H:MM", rounding to the nearest minute and preserving sign.
+// Used for datapoint values, which are exact logged amounts.
+export function formatClocky(hours: number): string {
+  const totalMinutes = Math.round(Math.abs(hours) * 60);
   const sign = hours < 0 && totalMinutes > 0 ? "-" : "";
   const h = Math.floor(totalMinutes / 60);
   const m = totalMinutes % 60;
   return `${sign}${h}:${m.toString().padStart(2, "0")}`;
 }
 
-// Rewrite the leading numeric value of a limsum/limsumdate string in clocky form,
-// leaving the rest ("due Sat by 09:00") untouched. Keeps an explicit leading "+".
-export function clockifyLimsum(limsum: string): string {
-  return limsum.replace(/^[+-]?\d+(\.\d+)?/, (m) => {
-    const s = formatClocky(Number(m), true);
-    return m.startsWith("+") ? `+${s}` : s;
-  });
+// Beeminder reports the clocky amount due (baremin) as a signed "HH:MM:SS"
+// string, precise to the second: "+00:06:00", "+00:06:01". Reformat to "H:MM",
+// rounding any partial minute UP so the amount never reads as less than what's
+// actually required ("00:06:01" → "0:07"). Returns "" when there's no clock
+// value. We use this rather than limsum's leading number, which is unreliable
+// for clocky goals — Beeminder may print "+1" for a six-minute amount.
+export function formatClockyClock(clock: string): string {
+  const m = clock.match(/(-)?(\d+):(\d+):(\d+)/);
+  if (!m) return "";
+  const totalMinutes = Math.ceil((+m[2] * 3600 + +m[3] * 60 + +m[4]) / 60);
+  const sign = m[1] && totalMinutes > 0 ? "-" : "";
+  const h = Math.floor(totalMinutes / 60);
+  const min = totalMinutes % 60;
+  return `${sign}${h}:${min.toString().padStart(2, "0")}`;
+}
+
+// Rewrite the leading numeric amount of a limsum/limsumdate string ("+1 due Mon
+// by 13:00") with the clocky amount due taken from `baremin` ("+00:06:00" →
+// "+0:06"), keeping the string's own leading sign and leaving the "due …" tail
+// untouched.
+export function clockifyLimsum(limsum: string, baremin: string): string {
+  const amount = formatClockyClock(baremin).replace(/^[+-]/, "");
+  return limsum.replace(/^([+-]?)\d+(\.\d+)?/, (_m, sign) => `${sign}${amount}`);
 }

--- a/src/lib/countdown.spec.ts
+++ b/src/lib/countdown.spec.ts
@@ -30,8 +30,8 @@ describe("secondsUntil", () => {
 });
 
 describe("getPrefix", () => {
-  const goal = (o: { baremin?: string; limsum?: string; hhmmformat?: boolean }) =>
-    ({ baremin: "", limsum: "", hhmmformat: false, ...o }) as Parameters<
+  const goal = (o: { baremin?: string; hhmmformat?: boolean }) =>
+    ({ baremin: "", hhmmformat: false, ...o }) as Parameters<
       typeof getPrefix
     >[0];
 
@@ -44,23 +44,22 @@ describe("getPrefix", () => {
     expect(getPrefix(goal({ baremin: "-3" }))).toBe("-3 in");
   });
 
-  it("rounds a clocky goal's amount up to the next minute", () => {
-    // 0.0912h = 5.47min → ceils to 0:06, matching the goal detail page rather
-    // than Beeminder's nearest-minute baremin of "0:05".
+  it("reformats a clocky goal's baremin, rounding partial minutes up", () => {
+    // baremin is second-precise; 00:05:28 must not read as 0:05.
     expect(
-      getPrefix(goal({ baremin: "0:05", limsum: "0.0912 in 0 days", hhmmformat: true }))
+      getPrefix(goal({ baremin: "+00:05:28", hhmmformat: true }))
     ).toBe("0:06 in");
   });
 
   it("keeps a clocky minus sign", () => {
     expect(
-      getPrefix(goal({ limsum: "-1.25 in 2 days", hhmmformat: true }))
+      getPrefix(goal({ baremin: "-01:15:00", hhmmformat: true }))
     ).toBe("-1:15 in");
   });
 
   it("formats an exact-minute clocky amount without a ceil bump", () => {
-    expect(getPrefix(goal({ limsum: "1 in 0 days", hhmmformat: true }))).toBe("1:00 in");
-    expect(getPrefix(goal({ limsum: "0.5 in 0 days", hhmmformat: true }))).toBe("0:30 in");
+    expect(getPrefix(goal({ baremin: "+01:00:00", hhmmformat: true }))).toBe("1:00 in");
+    expect(getPrefix(goal({ baremin: "+00:30:00", hhmmformat: true }))).toBe("0:30 in");
   });
 
   it("degrades to a bare ' in' when there's no amount", () => {

--- a/src/lib/countdown.ts
+++ b/src/lib/countdown.ts
@@ -1,5 +1,5 @@
 import { Goal } from "../services/beeminder";
-import { formatClocky } from "./clocky";
+import { formatClockyClock } from "./clocky";
 
 // The math behind the goal countdown: how long until a goal derails, which time
 // unit to show that in, and the rate prefix parsed from Beeminder's `baremin`.
@@ -28,17 +28,16 @@ export function secondsUntil(losedate: number, now: Date = new Date()): number {
 }
 
 // The rate prefix shown before the countdown. For clocky (hhmmformat) goals we
-// format the raw decimal amount from `limsum` ourselves, rounding partial
-// minutes up so the grid never reads less than the goal detail page — which
-// clockifies the same decimal — and stays pessimistic. Beeminder's own
-// `baremin` rounds to the nearest minute (0.0912h → "0:05", not "0:06"), so we
-// don't trust it for clocky goals. For other goals we show `baremin` directly.
+// reformat Beeminder's `baremin` — a second-precise "HH:MM:SS" amount due — to
+// "H:MM", rounding partial minutes up so we stay pessimistic. We can't use
+// limsum's leading number here: it's unreliable for clocky goals (Beeminder may
+// print "+1" for a six-minute amount). For other goals we show `baremin`
+// directly.
 export function getPrefix(
-  g: Pick<Goal, "baremin" | "limsum" | "hhmmformat">
+  g: Pick<Goal, "baremin" | "hhmmformat">
 ): string {
   if (g.hhmmformat) {
-    const amount = g.limsum.match(/^[+-]?\d+(\.\d+)?/)?.[0];
-    return `${amount ? formatClocky(Number(amount), true) : ""} in`;
+    return `${formatClockyClock(g.baremin)} in`;
   }
   const sign = g.baremin.includes("-") ? "-" : "";
   const number = g.baremin.match(/(\d+\.?\d?\d?)/)?.[1] || "";


### PR DESCRIPTION
## Problem

The flipper goal showed **1:00** due in the grid when Beeminder itself only had **6 minutes** due.

Root cause: the clocky-goal formatting assumed the leading number of Beeminder's `limsum` was the decimal-hours amount due. It isn't — for flipper, Beeminder prints `limsum: "+1 in 0 days"` for a six-minute amount, so `formatClocky(1)` produced `1:00`. That `+1` isn't hours at all.

## Fix

Read the amount from `baremin` instead (`"+00:06:00"`), which is authoritative and precise to the second, then round any partial minute **up** to stay pessimistic (`"H:MM"`).

Verified `baremin` has this `+HH:MM:SS` shape and matches `safebump - curval` across all 10 clocky goals on the account (`+00:06:00`, `+00:57:01`, `+00:04:16`, …). The old `"0:05"` fixture the previous approach was built on was fabricated, not real API data.

Both consumers shared the bug and are fixed:
- Grid countdown (`getPrefix`) → now uses `baremin`.
- Goal detail page (`clockifyLimsum` on `limsumdate`, which also carried the bogus `+1`) → amount now sourced from `baremin`.

Also dropped the now-dead `roundUp` param from `formatClocky` (only the new `formatClockyClock` needs ceil-to-minute). `datapointRow`'s `formatClocky(point.value)` is untouched — those are exact logged values, correctly rounded to nearest.

## Testing

- New unit coverage for `formatClockyClock` (round-up, exact-minute no-bump, negative sign, signed-zero guard, empty/malformed input) and updated `clockifyLimsum` / `getPrefix` specs against real `baremin` fixtures.
- Full suite: 151 tests pass. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)